### PR TITLE
Add image building and loading part in README.md and CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,12 +3,12 @@
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
 - [Contributing guidelines](#contributing-guidelines)
-    - [Contributions](#contributions)
-    - [Certificate of Origin](#certificate-of-origin)
-    - [Contributing A Patch](#contributing-a-patch)
-    - [Issue and Pull Request Management](#issue-and-pull-request-management)
-    - [Pre-check before submitting a PR](#pre-check-before-submitting-a-pr)
-    - [Build images](#build-images)
+  - [Contributions](#contributions)
+  - [Certificate of Origin](#certificate-of-origin)
+  - [Contributing A Patch](#contributing-a-patch)
+  - [Issue and Pull Request Management](#issue-and-pull-request-management)
+  - [Pre-check before submitting a PR](#pre-check-before-submitting-a-pr)
+  - [Build images](#build-images)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -62,7 +62,12 @@ make test-integration
 Run e2e testing. During e2e testing, hub and managed cluster share the same Kubernetes cluster.
 ```shell
 export KUBECONFIG=</path/to/kubeconfig>
-make test-integration
+
+make images
+
+kind load docker-image quay.io/open-cluster-management-io/helloworld-addon:latest --name {your cluster name}
+
+make test-e2e
 ```
 
 ## Build images

--- a/README.md
+++ b/README.md
@@ -33,9 +33,15 @@ Set environment variables.
 export KUBECONFIG=</path/to/hub_cluster/kubeconfig>
 ```
 
-Override the docker image (optional)
+Build the docker image to run the sample addon.
 ```sh
-export EXAMPLE_IMAGE_NAME=<your_own_image_name> # export EXAMPLE_IMAGE_NAME=quay.io/open-cluster-management-io/helloworld-addon:latest
+make images
+export EXAMPLE_IMAGE_NAME=<helloworld_addon_image_name> # export EXAMPLE_IMAGE_NAME=quay.io/open-cluster-management-io/helloworld-addon:latest
+```
+
+If your are using kind, load image into kind cluster.
+```sh
+kind load docker-image <helloworld_addon_image_name> # kind load docker-image quay.io/open-cluster-management-io/helloworld-addon:latest
 ```
 
 And then deploy helloworld addon contoller on hub cluster


### PR DESCRIPTION
The image quay.io/open-cluster-management-io/helloworld-addon can't not been download because of auth issue. So users should build it by themselves.

Signed-off-by: xuezhaojun <zxue@redhat.com>