### PR TITLE
throw an error when signer returns empty cert

### DIFF
--- a/pkg/addonmanager/controllers/certificate/csrsign.go
+++ b/pkg/addonmanager/controllers/certificate/csrsign.go
@@ -138,6 +138,9 @@ func (c *csrSignController) sync(ctx context.Context, syncCtx factory.SyncContex
 	}
 
 	csr.Status.Certificate = registrationOption.CSRSign(csr)
+	if len(csr.Status.Certificate) == 0 {
+		return fmt.Errorf("invalid client certificate generated for addon csr %q", csr.Name)
+	}
 
 	_, err = c.kubeClient.CertificatesV1().CertificateSigningRequests().UpdateStatus(ctx, csr, metav1.UpdateOptions{})
 	if err != nil {


### PR DESCRIPTION
The related issue: https://github.com/open-cluster-management/backlog/issues/15912
Signed-off-by: Yang Le <yangle@redhat.com>