### PR TITLE
Order manifests from HelmAgentAddon

### DIFF
--- a/pkg/addonfactory/helm_agentaddon.go
+++ b/pkg/addonfactory/helm_agentaddon.go
@@ -2,6 +2,7 @@ package addonfactory
 
 import (
 	"fmt"
+	"sort"
 
 	"helm.sh/helm/v3/pkg/chart"
 	"helm.sh/helm/v3/pkg/chartutil"
@@ -38,7 +39,8 @@ func newHelmAgentAddon(
 		decoder:           serializer.NewCodecFactory(scheme).UniversalDeserializer(),
 		chart:             chart,
 		getValuesFuncs:    getValuesFuncs,
-		agentAddonOptions: agentAddonOptions}
+		agentAddonOptions: agentAddonOptions,
+	}
 }
 
 func (a *HelmAgentAddon) Manifests(
@@ -70,7 +72,17 @@ func (a *HelmAgentAddon) Manifests(
 	if err != nil {
 		return objects, err
 	}
-	for _, data := range templates {
+
+	// sort the filenames of the templates so the manifests are ordered consistently
+	keys := make([]string, 0, len(templates))
+	for k := range templates {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	for _, k := range keys {
+		data := templates[k]
+
 		if len(data) == 0 {
 			continue
 		}


### PR DESCRIPTION
Since maps are iterated in random orders, the output of Manifests() was
changing its ordering every time it was called. This caused the
ManifestWork to be constantly changing.

This orders the manifests by file name in the chart.

Signed-off-by: Justin Kulikauskas <jkulikau@redhat.com>