### PR TITLE
Skip templates if 'Kind' not present

### DIFF
--- a/pkg/addonfactory/helm_agentaddon.go
+++ b/pkg/addonfactory/helm_agentaddon.go
@@ -89,6 +89,10 @@ func (a *HelmAgentAddon) Manifests(
 		klog.V(4).Infof("%v/n", data)
 		object, _, err := a.decoder.Decode([]byte(data), nil, nil)
 		if err != nil {
+			if runtime.IsMissingKind(err) {
+				klog.V(4).Infof("Skipping template %v, reason: %v", k, err)
+				continue
+			}
 			return nil, err
 		}
 		objects = append(objects, object)


### PR DESCRIPTION
A template file might have a conditional block around the resource,
allowing it to be enabled/disabled based on other variables. Previously,
the controller could not handle this, it would error with a message like
```
controller failed to sync "...", err: Object 'Kind' is missing in '...'
```

Signed-off-by: Justin Kulikauskas <jkulikau@redhat.com>