### PR TITLE
add WithTrimCRDDescription configuration for addonfactory

### DIFF
--- a/pkg/addonfactory/helm_agentaddon.go
+++ b/pkg/addonfactory/helm_agentaddon.go
@@ -24,22 +24,20 @@ type helmBuiltinValues struct {
 }
 
 type HelmAgentAddon struct {
-	decoder           runtime.Decoder
-	chart             *chart.Chart
-	getValuesFuncs    []GetValuesFunc
-	agentAddonOptions agent.AgentAddonOptions
+	decoder            runtime.Decoder
+	chart              *chart.Chart
+	getValuesFuncs     []GetValuesFunc
+	agentAddonOptions  agent.AgentAddonOptions
+	trimCRDDescription bool
 }
 
-func newHelmAgentAddon(
-	scheme *runtime.Scheme,
-	chart *chart.Chart,
-	getValuesFuncs []GetValuesFunc,
-	agentAddonOptions agent.AgentAddonOptions) *HelmAgentAddon {
+func newHelmAgentAddon(factory *AgentAddonFactory, chart *chart.Chart) *HelmAgentAddon {
 	return &HelmAgentAddon{
-		decoder:           serializer.NewCodecFactory(scheme).UniversalDeserializer(),
-		chart:             chart,
-		getValuesFuncs:    getValuesFuncs,
-		agentAddonOptions: agentAddonOptions,
+		decoder:            serializer.NewCodecFactory(factory.scheme).UniversalDeserializer(),
+		chart:              chart,
+		getValuesFuncs:     factory.getValuesFuncs,
+		agentAddonOptions:  factory.agentAddonOptions,
+		trimCRDDescription: factory.trimCRDDescription,
 	}
 }
 
@@ -98,6 +96,9 @@ func (a *HelmAgentAddon) Manifests(
 		objects = append(objects, object)
 	}
 
+	if a.trimCRDDescription {
+		objects = trimCRDDescription(objects)
+	}
 	return objects, nil
 }
 

--- a/pkg/addonfactory/helm_agentaddon_test.go
+++ b/pkg/addonfactory/helm_agentaddon_test.go
@@ -103,6 +103,7 @@ func TestChartAgentAddon_Manifests(t *testing.T) {
 			agentAddon, err := NewAgentAddonFactory(c.addonName, chartFS, "testmanifests/chart").
 				WithGetValuesFuncs(getValues, GetValuesFromAddonAnnotation).
 				WithScheme(c.scheme).
+				WithTrimCRDDescription().
 				BuildHelmAgentAddon()
 			if err != nil {
 				t.Errorf("expected no error, got err %v", err)
@@ -140,13 +141,247 @@ func TestChartAgentAddon_Manifests(t *testing.T) {
 					if object.Name != "test.cluster.open-cluster-management.io" {
 						t.Errorf("expected v1 crd test, but got %v", object.Name)
 					}
+					if !validateTrimCRDv1(object) {
+						t.Errorf("the crd is not compredded")
+					}
 				case *apiextensionsv1beta1.CustomResourceDefinition:
 					if object.Name != "clusterclaims.cluster.open-cluster-management.io" {
 						t.Errorf("expected v1 crd clusterclaims, but got %v", object.Name)
+					}
+					if !validateTrimCRDv1beta1(object) {
+						t.Errorf("the crd is not compredded")
 					}
 				}
 
 			}
 		})
 	}
+}
+
+func validateTrimCRDv1(crd *apiextensionsv1.CustomResourceDefinition) bool {
+	versions := crd.Spec.Versions
+	for i := range versions {
+		properties := versions[i].Schema.OpenAPIV3Schema.Properties
+		for _, p := range properties {
+			if hasDescriptionV1(&p) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func hasDescriptionV1(p *apiextensionsv1.JSONSchemaProps) bool {
+	if p == nil {
+		return false
+	}
+
+	if p.Description != "" {
+		return true
+	}
+
+	if p.Items != nil {
+		if hasDescriptionV1(p.Items.Schema) {
+			return true
+		}
+		for _, v := range p.Items.JSONSchemas {
+			if hasDescriptionV1(&v) {
+				return true
+			}
+		}
+	}
+
+	if len(p.AllOf) != 0 {
+		for _, v := range p.AllOf {
+			if hasDescriptionV1(&v) {
+				return true
+			}
+		}
+	}
+
+	if len(p.OneOf) != 0 {
+		for _, v := range p.OneOf {
+			if hasDescriptionV1(&v) {
+				return true
+			}
+		}
+	}
+
+	if len(p.AnyOf) != 0 {
+		for _, v := range p.AnyOf {
+			if hasDescriptionV1(&v) {
+				return true
+			}
+		}
+	}
+
+	if p.Not != nil {
+		if hasDescriptionV1(p.Not) {
+			return true
+		}
+	}
+
+	if len(p.Properties) != 0 {
+		for _, v := range p.Properties {
+			if hasDescriptionV1(&v) {
+				return true
+			}
+		}
+	}
+
+	if len(p.PatternProperties) != 0 {
+		for _, v := range p.PatternProperties {
+			if hasDescriptionV1(&v) {
+				return true
+			}
+		}
+	}
+
+	if p.AdditionalProperties != nil {
+		if hasDescriptionV1(p.AdditionalProperties.Schema) {
+			return true
+		}
+	}
+
+	if len(p.Dependencies) != 0 {
+		for _, v := range p.Dependencies {
+			if hasDescriptionV1(v.Schema) {
+				return true
+			}
+		}
+	}
+
+	if p.AdditionalItems != nil {
+		if hasDescriptionV1(p.AdditionalItems.Schema) {
+			return true
+		}
+	}
+
+	if len(p.Definitions) != 0 {
+		for _, v := range p.Definitions {
+			if hasDescriptionV1(&v) {
+				return true
+			}
+		}
+	}
+
+	if p.ExternalDocs != nil && p.ExternalDocs.Description != "" {
+		return true
+	}
+
+	return false
+}
+
+func validateTrimCRDv1beta1(crd *apiextensionsv1beta1.CustomResourceDefinition) bool {
+	versions := crd.Spec.Versions
+	for i := range versions {
+		properties := versions[i].Schema.OpenAPIV3Schema.Properties
+		for _, p := range properties {
+			if hasDescriptionV1beta1(&p) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func hasDescriptionV1beta1(p *apiextensionsv1beta1.JSONSchemaProps) bool {
+	if p == nil {
+		return false
+	}
+
+	if p.Description != "" {
+		return true
+	}
+
+	if p.Items != nil {
+		if hasDescriptionV1beta1(p.Items.Schema) {
+			return true
+		}
+		for _, v := range p.Items.JSONSchemas {
+			if hasDescriptionV1beta1(&v) {
+				return true
+			}
+		}
+	}
+
+	if len(p.AllOf) != 0 {
+		for _, v := range p.AllOf {
+			if hasDescriptionV1beta1(&v) {
+				return true
+			}
+		}
+	}
+
+	if len(p.OneOf) != 0 {
+		for _, v := range p.OneOf {
+			if hasDescriptionV1beta1(&v) {
+				return true
+			}
+		}
+	}
+
+	if len(p.AnyOf) != 0 {
+		for _, v := range p.AnyOf {
+			if hasDescriptionV1beta1(&v) {
+				return true
+			}
+		}
+	}
+
+	if p.Not != nil {
+		if hasDescriptionV1beta1(p.Not) {
+			return true
+		}
+	}
+
+	if len(p.Properties) != 0 {
+		for _, v := range p.Properties {
+			if hasDescriptionV1beta1(&v) {
+				return true
+			}
+		}
+	}
+
+	if len(p.PatternProperties) != 0 {
+		for _, v := range p.PatternProperties {
+			if hasDescriptionV1beta1(&v) {
+				return true
+			}
+		}
+	}
+
+	if p.AdditionalProperties != nil {
+		if hasDescriptionV1beta1(p.AdditionalProperties.Schema) {
+			return true
+		}
+	}
+
+	if len(p.Dependencies) != 0 {
+		for _, v := range p.Dependencies {
+			if hasDescriptionV1beta1(v.Schema) {
+				return true
+			}
+		}
+	}
+
+	if p.AdditionalItems != nil {
+		if hasDescriptionV1beta1(p.AdditionalItems.Schema) {
+			return true
+		}
+	}
+
+	if len(p.Definitions) != 0 {
+		for _, v := range p.Definitions {
+			if hasDescriptionV1beta1(&v) {
+				return true
+			}
+		}
+	}
+
+	if p.ExternalDocs != nil && p.ExternalDocs.Description != "" {
+		return true
+	}
+
+	return false
 }

--- a/pkg/addonfactory/template_agentaddon.go
+++ b/pkg/addonfactory/template_agentaddon.go
@@ -26,21 +26,20 @@ type templateFile struct {
 }
 
 type TemplateAgentAddon struct {
-	decoder           runtime.Decoder
-	templateFiles     []templateFile
-	getValuesFuncs    []GetValuesFunc
-	agentAddonOptions agent.AgentAddonOptions
+	decoder            runtime.Decoder
+	templateFiles      []templateFile
+	getValuesFuncs     []GetValuesFunc
+	agentAddonOptions  agent.AgentAddonOptions
+	trimCRDDescription bool
 }
 
-func newTemplateAgentAddon(
-	scheme *runtime.Scheme,
-	getValuesFuncs []GetValuesFunc,
-	agentAddonOptions agent.AgentAddonOptions) *TemplateAgentAddon {
+func newTemplateAgentAddon(factory *AgentAddonFactory) *TemplateAgentAddon {
 	return &TemplateAgentAddon{
-		decoder: serializer.NewCodecFactory(scheme).UniversalDeserializer(),
-
-		getValuesFuncs:    getValuesFuncs,
-		agentAddonOptions: agentAddonOptions}
+		decoder:            serializer.NewCodecFactory(factory.scheme).UniversalDeserializer(),
+		getValuesFuncs:     factory.getValuesFuncs,
+		agentAddonOptions:  factory.agentAddonOptions,
+		trimCRDDescription: factory.trimCRDDescription,
+	}
 }
 
 func (a *TemplateAgentAddon) Manifests(
@@ -70,6 +69,9 @@ func (a *TemplateAgentAddon) Manifests(
 		objects = append(objects, object)
 	}
 
+	if a.trimCRDDescription {
+		objects = trimCRDDescription(objects)
+	}
 	return objects, nil
 }
 

--- a/pkg/addonfactory/trimcrds.go
+++ b/pkg/addonfactory/trimcrds.go
@@ -1,0 +1,211 @@
+package addonfactory
+
+import (
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func trimCRDDescription(objects []runtime.Object) []runtime.Object {
+	rstObjects := []runtime.Object{}
+	for _, o := range objects {
+		switch object := o.(type) {
+		case *apiextensionsv1.CustomResourceDefinition:
+			trimCRDv1Description(object)
+			rstObjects = append(rstObjects, object)
+		case *apiextensionsv1beta1.CustomResourceDefinition:
+			trimCRDv1beta1Description(object)
+			rstObjects = append(rstObjects, object)
+		default:
+			rstObjects = append(rstObjects, object)
+		}
+	}
+
+	return rstObjects
+}
+
+// trimCRDv1Description is to remove the description info in the versions of CRD spec
+func trimCRDv1Description(crd *apiextensionsv1.CustomResourceDefinition) {
+	versions := crd.Spec.Versions
+	for i := range versions {
+		removeDescriptionV1(versions[i].Schema.OpenAPIV3Schema)
+	}
+}
+
+func removeDescriptionV1(p *apiextensionsv1.JSONSchemaProps) {
+	if p == nil {
+		return
+	}
+
+	p.Description = ""
+
+	if p.Items != nil {
+		removeDescriptionV1(p.Items.Schema)
+		for i := range p.Items.JSONSchemas {
+			removeDescriptionV1(&p.Items.JSONSchemas[i])
+		}
+	}
+
+	if len(p.AllOf) != 0 {
+		for i := range p.AllOf {
+			removeDescriptionV1(&p.AllOf[i])
+		}
+	}
+
+	if len(p.OneOf) != 0 {
+		for i := range p.OneOf {
+			removeDescriptionV1(&p.OneOf[i])
+		}
+	}
+
+	if len(p.AnyOf) != 0 {
+		for i := range p.AnyOf {
+			removeDescriptionV1(&p.AnyOf[i])
+		}
+	}
+
+	if p.Not != nil {
+		removeDescriptionV1(p.Not)
+	}
+
+	if len(p.Properties) != 0 {
+		newProperties := map[string]apiextensionsv1.JSONSchemaProps{}
+		for k, v := range p.Properties {
+			removeDescriptionV1(&v)
+			newProperties[k] = v
+		}
+		p.Properties = newProperties
+	}
+
+	if len(p.PatternProperties) != 0 {
+		newProperties := map[string]apiextensionsv1.JSONSchemaProps{}
+		for k, v := range p.PatternProperties {
+			removeDescriptionV1(&v)
+			newProperties[k] = v
+		}
+		p.PatternProperties = newProperties
+	}
+
+	if p.AdditionalProperties != nil {
+		removeDescriptionV1(p.AdditionalProperties.Schema)
+	}
+
+	if len(p.Dependencies) != 0 {
+		newDependencies := map[string]apiextensionsv1.JSONSchemaPropsOrStringArray{}
+		for k, v := range p.Dependencies {
+			removeDescriptionV1(v.Schema)
+			newDependencies[k] = v
+		}
+		p.Dependencies = newDependencies
+	}
+
+	if p.AdditionalItems != nil {
+		removeDescriptionV1(p.AdditionalItems.Schema)
+	}
+
+	if len(p.Definitions) != 0 {
+		newDefinitions := map[string]apiextensionsv1.JSONSchemaProps{}
+		for k, v := range p.Definitions {
+			removeDescriptionV1(&v)
+			newDefinitions[k] = v
+		}
+		p.Definitions = newDefinitions
+	}
+
+	if p.ExternalDocs != nil {
+		p.ExternalDocs.Description = ""
+	}
+}
+
+// trimCRDv1beta1Description is to remove the description info in the versions of CRD spec
+func trimCRDv1beta1Description(crd *apiextensionsv1beta1.CustomResourceDefinition) {
+	versions := crd.Spec.Versions
+	for i := range versions {
+		removeDescriptionV1beta1(versions[i].Schema.OpenAPIV3Schema)
+	}
+}
+
+func removeDescriptionV1beta1(p *apiextensionsv1beta1.JSONSchemaProps) {
+	if p == nil {
+		return
+	}
+
+	p.Description = ""
+
+	if p.Items != nil {
+		removeDescriptionV1beta1(p.Items.Schema)
+		for i := range p.Items.JSONSchemas {
+			removeDescriptionV1beta1(&p.Items.JSONSchemas[i])
+		}
+	}
+
+	if len(p.AllOf) != 0 {
+		for i := range p.AllOf {
+			removeDescriptionV1beta1(&p.AllOf[i])
+		}
+	}
+
+	if len(p.OneOf) != 0 {
+		for i := range p.OneOf {
+			removeDescriptionV1beta1(&p.OneOf[i])
+		}
+	}
+
+	if len(p.AnyOf) != 0 {
+		for i := range p.AnyOf {
+			removeDescriptionV1beta1(&p.AnyOf[i])
+		}
+	}
+
+	if p.Not != nil {
+		removeDescriptionV1beta1(p.Not)
+	}
+
+	if len(p.Properties) != 0 {
+		newProperties := map[string]apiextensionsv1beta1.JSONSchemaProps{}
+		for k, v := range p.Properties {
+			removeDescriptionV1beta1(&v)
+			newProperties[k] = v
+		}
+		p.Properties = newProperties
+	}
+
+	if len(p.PatternProperties) != 0 {
+		newProperties := map[string]apiextensionsv1beta1.JSONSchemaProps{}
+		for k, v := range p.PatternProperties {
+			removeDescriptionV1beta1(&v)
+			newProperties[k] = v
+		}
+		p.PatternProperties = newProperties
+	}
+
+	if p.AdditionalProperties != nil {
+		removeDescriptionV1beta1(p.AdditionalProperties.Schema)
+	}
+
+	if len(p.Dependencies) != 0 {
+		newDependencies := map[string]apiextensionsv1beta1.JSONSchemaPropsOrStringArray{}
+		for k, v := range p.Dependencies {
+			removeDescriptionV1beta1(v.Schema)
+			newDependencies[k] = v
+		}
+		p.Dependencies = newDependencies
+	}
+
+	if p.AdditionalItems != nil {
+		removeDescriptionV1beta1(p.AdditionalItems.Schema)
+	}
+
+	if len(p.Definitions) != 0 {
+		newDefinitions := map[string]apiextensionsv1beta1.JSONSchemaProps{}
+		for k, v := range p.Definitions {
+			removeDescriptionV1beta1(&v)
+			newDefinitions[k] = v
+		}
+		p.Definitions = newDefinitions
+	}
+
+	if p.ExternalDocs != nil {
+		p.ExternalDocs.Description = ""
+	}
+}


### PR DESCRIPTION
there will be a large workload in manifestWork if there are several CRDs in the addon manifests. in CRD, the Description info  takes up the most of size.
so  add WithTrimCRDDescription config for the addonfactory build to remove the Description info of CRDs to reduce the workload size of manifestWork.  

Signed-off-by: Zhiwei Yin <zyin@redhat.com>