### PR TITLE
should apply pre-delete manifestwork when the managedCluster is deleting

### DIFF
--- a/pkg/addonmanager/controllers/agentdeploy/hookcontroller.go
+++ b/pkg/addonmanager/controllers/agentdeploy/hookcontroller.go
@@ -128,11 +128,7 @@ func (c *addonHookDeployController) sync(ctx context.Context, syncCtx factory.Sy
 		return err
 	}
 
-	if !managedCluster.DeletionTimestamp.IsZero() {
-		// managed cluster is deleting, remove cache.
-		c.cache.removeCache(preDeleteHookWorkName(addonName), clusterName)
-		return nil
-	}
+	// should continue to apply pre-delete hook when the managedCluster is deleting.
 
 	managedClusterAddon, err := c.managedClusterAddonLister.ManagedClusterAddOns(clusterName).Get(addonName)
 	if errors.IsNotFound(err) {


### PR DESCRIPTION
 should apply pre-delete manifestwork when the managedCluster and managedClusterAddon are deleting.

Signed-off-by: Zhiwei Yin <zyin@redhat.com>