### PR TITLE
make the chart dir support containing file path suffix

### DIFF
--- a/pkg/addonfactory/helper.go
+++ b/pkg/addonfactory/helper.go
@@ -142,7 +142,8 @@ func getFiles(manifestFS embed.FS) ([]string, error) {
 }
 
 func stripPrefix(chartPrefix, path string) string {
-	chartPrefixLen := len(strings.Split(chartPrefix, string(filepath.Separator)))
+	prefixNoPathSeparatorSuffix := strings.TrimSuffix(chartPrefix, string(filepath.Separator))
+	chartPrefixLen := len(strings.Split(prefixNoPathSeparatorSuffix, string(filepath.Separator)))
 	pathValues := strings.Split(path, string(filepath.Separator))
 	return strings.Join(pathValues[chartPrefixLen:], string(filepath.Separator))
 }

--- a/pkg/addonfactory/helper_test.go
+++ b/pkg/addonfactory/helper_test.go
@@ -88,3 +88,46 @@ func TestMergeStructValues(t *testing.T) {
 		})
 	}
 }
+
+func TestStripPrefix(t *testing.T) {
+	cases := []struct {
+		name   string
+		prefix string
+		path   string
+		expect string
+	}{
+		{
+			name:   "path file prefix without / suffix",
+			prefix: "manifests/chart-management",
+			path:   "manifests/chart-management/values.yaml",
+			expect: "values.yaml",
+		},
+		{
+			name:   "path file prefix with / suffix",
+			prefix: "manifests/chart-management/",
+			path:   "manifests/chart-management/values.yaml",
+			expect: "values.yaml",
+		},
+		{
+			name:   "path folder prefix without / suffix",
+			prefix: "manifests/chart-management",
+			path:   "manifests/chart-management/templates/service_account.yaml",
+			expect: "templates/service_account.yaml",
+		},
+		{
+			name:   "path folder prefix with / suffix",
+			prefix: "manifests/chart-management/",
+			path:   "manifests/chart-management/templates/service_account.yaml",
+			expect: "templates/service_account.yaml",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			result := stripPrefix(c.prefix, c.path)
+			if result != c.expect {
+				t.Errorf("name %s: expected values %v, but got values %v", c.name, c.expect, result)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Signed-off-by: zhujian <jiazhu@redhat.com>

Why do we need this:

In the following case, I need to set the chart dir `manifests/chart/`(with the suffix `/`) to exclude the `manifests/chart-management` files.
```
manifests
├── chart
│   ├── Chart.yaml
│   ├── templates
│   │   ├── _helpers.tpl
│   │   ├── cluster_role.yaml
│   │   ├── cluster_role_binding.yaml
│   │   ├── namespace.yaml
│   │   └── service_account.yaml
│   └── values.yaml
└── chart-management
    ├── Chart.yaml
    ├── templates
    │   ├── _helpers.tpl
    │   ├── deployment.yaml
    │   ├── role.yaml
    │   ├── role_binding.yaml
    │   ├── route.yaml
    │   ├── service.yaml
    │   └── service_account.yaml
    └── values.yaml
```