### PR TITLE
change kube version to annotation for helloworld helm example

### DIFF
--- a/examples/helloworld_helm/manifests/charts/helloworld/templates/deployment.yaml
+++ b/examples/helloworld_helm/manifests/charts/helloworld/templates/deployment.yaml
@@ -9,6 +9,7 @@ metadata:
     release: {{ .Release.Name }}
     clusterName: {{ .Values.clusterName }}
     addonInstallNamespace: {{ .Values.addonInstallNamespace }}
+  annotations:
     kubeVersion: {{ .Capabilities.KubeVersion }}
 spec:
   replicas: 1


### PR DESCRIPTION
Signed-off-by: zhujian <jiazhu@redhat.com>

fix error for helloworldhelm example:
```
    message: 'failed to apply manifestwork: ManifestWork.work.open-cluster-management.io
      "addon-helloworldhelm-deploy" is invalid: spec.workload.manifests[1].metadata.labels:
      Invalid value: "v1.23.3+e419edf": a valid label must be an empty string or consist
      of alphanumeric characters, ''-'', ''_'' or ''.'', and must start and end with
      an alphanumeric character (e.g. ''MyValue'',  or ''my_value'',  or ''12345'',
      regex used for validation is ''(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?'')'
```