### PR TITLE
add an annotation to disable addon automatic installation

### DIFF
--- a/pkg/addonmanager/addontesting/helpers.go
+++ b/pkg/addonmanager/addontesting/helpers.go
@@ -153,6 +153,12 @@ func DeleteManagedCluster(c *clusterv1.ManagedCluster) *clusterv1.ManagedCluster
 	return c
 }
 
+func SetManagedClusterAnnotation(c *clusterv1.ManagedCluster,
+	annotations map[string]string) *clusterv1.ManagedCluster {
+	c.Annotations = annotations
+	return c
+}
+
 func NewCSR(addon, cluster string) *certv1.CertificateSigningRequest {
 	return &certv1.CertificateSigningRequest{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/addonmanager/constants/constants.go
+++ b/pkg/addonmanager/constants/constants.go
@@ -76,6 +76,10 @@ const (
 	// HostingClusterValidityReasonInvalid is the reason of condition HostingClusterValidity indicating the hosting
 	// cluster is invalid
 	HostingClusterValidityReasonInvalid = "HostingClusterInvalid"
+
+	// DisableAddonAutomaticInstallationAnnotationKey is the annotation key for disabling the functionality of
+	// installing addon automatically
+	DisableAddonAutomaticInstallationAnnotationKey = "addon.open-cluster-management.io/disable-automatic-installation"
 )
 
 // DeployWorkName return the name of work for the addon

--- a/pkg/addonmanager/controllers/addoninstall/controller.go
+++ b/pkg/addonmanager/controllers/addoninstall/controller.go
@@ -2,6 +2,7 @@ package addoninstall
 
 import (
 	"context"
+	"strings"
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -9,6 +10,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	errorsutil "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/klog/v2"
+	"open-cluster-management.io/addon-framework/pkg/addonmanager/constants"
 	"open-cluster-management.io/addon-framework/pkg/agent"
 	"open-cluster-management.io/addon-framework/pkg/basecontroller/factory"
 	addonapiv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
@@ -78,6 +80,14 @@ func (c *addonInstallController) sync(ctx context.Context, syncCtx factory.SyncC
 	// if cluster is deleting, do not install addon
 	if !cluster.DeletionTimestamp.IsZero() {
 		klog.V(4).Infof("Cluster %q is deleting, skip addon deploy", clusterName)
+		return nil
+	}
+
+	if value, ok := cluster.Annotations[constants.DisableAddonAutomaticInstallationAnnotationKey]; ok &&
+		strings.EqualFold(value, "true") {
+
+		klog.V(4).Infof("Cluster %q has annotation %q, skip addon deploy",
+			clusterName, constants.DisableAddonAutomaticInstallationAnnotationKey)
 		return nil
 	}
 

--- a/pkg/addonmanager/controllers/addoninstall/controller_test.go
+++ b/pkg/addonmanager/controllers/addoninstall/controller_test.go
@@ -9,6 +9,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	clienttesting "k8s.io/client-go/testing"
 	"open-cluster-management.io/addon-framework/pkg/addonmanager/addontesting"
+	"open-cluster-management.io/addon-framework/pkg/addonmanager/constants"
 	"open-cluster-management.io/addon-framework/pkg/agent"
 	addonapiv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
 	fakeaddon "open-cluster-management.io/api/client/addon/clientset/versioned/fake"
@@ -87,6 +88,21 @@ func TestReconcile(t *testing.T) {
 			validateAddonActions: func(t *testing.T, actions []clienttesting.Action) {
 				if len(actions) != 0 {
 					t.Errorf("Should not install addon when controller is deleting")
+				}
+			},
+			testaddons: map[string]agent.AgentAddon{
+				"test": &testAgent{name: "test", strategy: agent.InstallAllStrategy("test")},
+			},
+		},
+		{
+			name:  "cluster has addon disable automatic installation annotation",
+			addon: []runtime.Object{},
+			cluster: []runtime.Object{addontesting.SetManagedClusterAnnotation(
+				addontesting.NewManagedCluster("cluster1"),
+				map[string]string{constants.DisableAddonAutomaticInstallationAnnotationKey: "true"})},
+			validateAddonActions: func(t *testing.T, actions []clienttesting.Action) {
+				if len(actions) != 0 {
+					t.Errorf("Should not install addon when cluster has disable automatic installation annotation")
 				}
 			},
 			testaddons: map[string]agent.AgentAddon{


### PR DESCRIPTION
Signed-off-by: zhujian <jiazhu@redhat.com>

Will not automatically install addon agent on the cluster which has `addon.open-cluster-management.io/disable-automatic-installation: "true"` annotation