### PR TITLE
remove template validation

### DIFF
--- a/pkg/addonfactory/addonfactory.go
+++ b/pkg/addonfactory/addonfactory.go
@@ -125,7 +125,6 @@ func (f *AgentAddonFactory) BuildHelmAgentAddon() (agent.AgentAddon, error) {
 	if err != nil {
 		return nil, err
 	}
-	// TODO: validate chart
 
 	agentAddon := newHelmAgentAddon(f, userChart)
 
@@ -152,9 +151,6 @@ func (f *AgentAddonFactory) BuildTemplateAgentAddon() (agent.AgentAddon, error) 
 	for _, file := range templateFiles {
 		template, err := f.fs.ReadFile(file)
 		if err != nil {
-			return nil, err
-		}
-		if err := agentAddon.validateTemplateData(file, template); err != nil {
 			return nil, err
 		}
 		agentAddon.addTemplateData(file, template)

--- a/pkg/addonfactory/template_agentaddon.go
+++ b/pkg/addonfactory/template_agentaddon.go
@@ -125,27 +125,6 @@ func (a *TemplateAgentAddon) getBuiltinValues(
 	return StructToValues(builtinValues)
 }
 
-// validateTemplateData validate template render and object decoder using  an empty cluster and addon
-func (a *TemplateAgentAddon) validateTemplateData(file string, data []byte) error {
-	configValues, err := a.getValues(&clusterv1.ManagedCluster{}, &addonapiv1alpha1.ManagedClusterAddOn{})
-	if err != nil {
-		return err
-	}
-
-	// There may be some manifests for hosting cluster only or for managed cluster only, so we ignore the missing kind
-	// error to bypass the empty file
-	raw := assets.MustCreateAssetFromTemplate(file, data, configValues).Data
-	_, _, err = a.decoder.Decode(raw, nil, nil)
-	if err != nil {
-		if !runtime.IsMissingKind(err) {
-			return err
-		}
-		klog.V(4).Infof("Validate template %v missing kind, reason: %v", file, err)
-	}
-
-	return nil
-}
-
 func (a *TemplateAgentAddon) addTemplateData(file string, data []byte) {
 	a.templateFiles = append(a.templateFiles, templateFile{name: file, content: data})
 }


### PR DESCRIPTION
Signed-off-by: Zhiwei Yin <zyin@redhat.com>

in some cases, there are some dependencies in getValues,  at the beginning the  dependencies is not ready before addon manager starts, the AgentAddon will fail to build when the getValues returns err in validateTemplateData.
