### PR TITLE
support manifests deletion orphan

### DIFF
--- a/examples/helloworld_helm/manifests/charts/helloworld/templates/deployment.yaml
+++ b/examples/helloworld_helm/manifests/charts/helloworld/templates/deployment.yaml
@@ -11,6 +11,7 @@ metadata:
     addonInstallNamespace: {{ .Values.addonInstallNamespace }}
   annotations:
     kubeVersion: {{ .Capabilities.KubeVersion }}
+    "addon-cluster-management.io/deletion-orphan": ""
 spec:
   replicas: 1
   selector:

--- a/pkg/addonmanager/constants/constants.go
+++ b/pkg/addonmanager/constants/constants.go
@@ -83,6 +83,10 @@ const (
 	// DisableAddonAutomaticInstallationAnnotationKey is the annotation key for disabling the functionality of
 	// installing addon automatically
 	DisableAddonAutomaticInstallationAnnotationKey = "addon.open-cluster-management.io/disable-automatic-installation"
+
+	// AnnotationDeletionOrphan is an annotation for the manifest which will not be cleaned up
+	// after the addon manifestWork is deleted.
+	AnnotationDeletionOrphan = "addon-cluster-management.io/deletion-orphan"
 )
 
 // DeployWorkNamePrefix returns the prefix of the work name for the addon


### PR DESCRIPTION
Signed-off-by: Zhiwei Yin <zyin@redhat.com>

support to set deletionOption for addon manifestWork by an annotation in the manifests.
will not clean up the manifest with the annotation `addon-cluster-management.io/deletion-orphan` when the addon manifestWork is deleted. 