### PR TITLE
add pre-delete and hostedLocation annotation and will deprecate the labels

### DIFF
--- a/docs/preDeleteHook.md
+++ b/docs/preDeleteHook.md
@@ -4,7 +4,7 @@ This doc is used to introduce how to add a pre-delete manifestWork for an AddOn.
 We support to use `Jobs` or `Pods` as a pre-delete manifestWork for an AddOn.
 
 # How it works
-1. Add the label `open-cluster-management.io/addon-pre-delete` to the `Jobs` or `Pods` manifests.
+1. Add the annotation `addon.open-cluster-management.io/addon-pre-delete` to the `Jobs` or `Pods` manifests.
 2. The `Jobs` or `Pods` will not be applied until the managedClusterAddon is deleted.
 3. The `Jobs` or `Pods` will be applied on the managed cluster by applying the manifestWork named `addon-<addon name>-pre-delete` when the managedClusterAddon is deleting.
 4. After the `Jobs` are `Completed` or `Pods` are in `Succeeded` phase, all the deployed manifestWorks will be deleted.

--- a/examples/helloworld_helm/manifests/charts/helloworld/templates/pre-delete-job.yaml
+++ b/examples/helloworld_helm/manifests/charts/helloworld/templates/pre-delete-job.yaml
@@ -3,8 +3,8 @@ apiVersion: batch/v1
 metadata:
   name: {{ template "helloworldhelm.name" . }}-cleanup-configmap
   namespace: {{ .Release.Namespace }}
-  labels:
-    "open-cluster-management.io/addon-pre-delete": ""
+  annotations:
+    "addon.open-cluster-management.io/addon-pre-delete": ""
 spec:
   manualSelector: true
   selector:

--- a/examples/helloworld_hosted/manifests/templates/clusterrole.yaml
+++ b/examples/helloworld_hosted/manifests/templates/clusterrole.yaml
@@ -2,7 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: helloworldhosted-agent
-  labels:
+  annotations:
     addon.open-cluster-management.io/hosted-manifest-location: none
 rules:
 - apiGroups: [""]

--- a/examples/helloworld_hosted/manifests/templates/clusterrolebinding.yaml
+++ b/examples/helloworld_hosted/manifests/templates/clusterrolebinding.yaml
@@ -2,7 +2,7 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: helloworldhosted-agent-{{ .AddonInstallNamespace }}
-  labels:
+  annotations:
     addon.open-cluster-management.io/hosted-manifest-location: none
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/examples/helloworld_hosted/manifests/templates/deployment.yaml
+++ b/examples/helloworld_hosted/manifests/templates/deployment.yaml
@@ -3,9 +3,10 @@ apiVersion: apps/v1
 metadata:
   name: helloworldhosted-agent
   namespace: {{ .AddonInstallNamespace }}
+  annotations:
+    addon.open-cluster-management.io/hosted-manifest-location: hosting
   labels:
     app: helloworldhosted-agent
-    addon.open-cluster-management.io/hosted-manifest-location: hosting
 spec:
   replicas: 1
   selector:

--- a/examples/helloworld_hosted/manifests/templates/namespacehosting.yaml
+++ b/examples/helloworld_hosted/manifests/templates/namespacehosting.yaml
@@ -3,6 +3,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: {{ .AddonInstallNamespace }}
+  annotations:
+    addon.open-cluster-management.io/hosted-manifest-location: hosting
   labels:
     addon.open-cluster-management.io/namespace: "true"
-    addon.open-cluster-management.io/hosted-manifest-location: hosting
+

--- a/examples/helloworld_hosted/manifests/templates/pre-delete-job.yaml
+++ b/examples/helloworld_hosted/manifests/templates/pre-delete-job.yaml
@@ -3,8 +3,8 @@ apiVersion: batch/v1
 metadata:
   name: helloworldhosted-cleanup-configmap
   namespace: {{ .AddonInstallNamespace }}
-  labels:
-    open-cluster-management.io/addon-pre-delete: ""
+  annotations:
+    addon.open-cluster-management.io/addon-pre-delete: ""
     addon.open-cluster-management.io/hosted-manifest-location: hosting
 spec:
   manualSelector: true

--- a/examples/helloworld_hosted/manifests/templates/role.yaml
+++ b/examples/helloworld_hosted/manifests/templates/role.yaml
@@ -3,7 +3,7 @@ kind: Role
 metadata:
   name: helloworldhosted-agent
   namespace: {{ .AddonInstallNamespace }}
-  labels:
+  annotations:
     addon.open-cluster-management.io/hosted-manifest-location: hosting
 rules:
 # leader election needs to operate configmaps

--- a/examples/helloworld_hosted/manifests/templates/rolebinding.yaml
+++ b/examples/helloworld_hosted/manifests/templates/rolebinding.yaml
@@ -3,7 +3,7 @@ kind: RoleBinding
 metadata:
   name: helloworldhosted-agent
   namespace: {{ .AddonInstallNamespace }}
-  labels:
+  annotations:
     addon.open-cluster-management.io/hosted-manifest-location: hosting
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/examples/helloworld_hosted/manifests/templates/serviceaccount.yaml
+++ b/examples/helloworld_hosted/manifests/templates/serviceaccount.yaml
@@ -3,5 +3,5 @@ apiVersion: v1
 metadata:
   name: helloworldhosted-agent-sa
   namespace: {{ .AddonInstallNamespace }}
-  labels:
+  annotations:
     addon.open-cluster-management.io/hosted-manifest-location: hosting

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	k8s.io/component-base v0.25.0
 	k8s.io/klog/v2 v2.70.1
 	k8s.io/utils v0.0.0-20220728103510-ee6ede2d64ed
-	open-cluster-management.io/api v0.9.1-0.20221212072517-d2016d321f33
+	open-cluster-management.io/api v0.9.1-0.20221222015712-61cf30907d02
 	sigs.k8s.io/controller-runtime v0.11.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -779,8 +779,8 @@ k8s.io/kube-openapi v0.0.0-20220803162953-67bda5d908f1 h1:MQ8BAZPZlWk3S9K4a9NCkI
 k8s.io/kube-openapi v0.0.0-20220803162953-67bda5d908f1/go.mod h1:C/N6wCaBHeBHkHUesQOQy2/MZqGgMAFPqGsGQLdbZBU=
 k8s.io/utils v0.0.0-20220728103510-ee6ede2d64ed h1:jAne/RjBTyawwAy0utX5eqigAwz/lQhTmy+Hr/Cpue4=
 k8s.io/utils v0.0.0-20220728103510-ee6ede2d64ed/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
-open-cluster-management.io/api v0.9.1-0.20221212072517-d2016d321f33 h1:uHTEdlnjyTt6+9LTWJREWMQHzuVToWVNd7FbSjvFcqY=
-open-cluster-management.io/api v0.9.1-0.20221212072517-d2016d321f33/go.mod h1:6BB/Y6r3hXlPjpJgDwIs6Ubxyx/kXXOg6D9Cntg1I9E=
+open-cluster-management.io/api v0.9.1-0.20221222015712-61cf30907d02 h1:QUO3HHm38/99Zr7+ZB3j6PoDpzRzFKOmBBXNMAgaKxs=
+open-cluster-management.io/api v0.9.1-0.20221222015712-61cf30907d02/go.mod h1:6BB/Y6r3hXlPjpJgDwIs6Ubxyx/kXXOg6D9Cntg1I9E=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=

--- a/pkg/addonmanager/addontesting/helpers.go
+++ b/pkg/addonmanager/addontesting/helpers.go
@@ -59,24 +59,22 @@ func NewHostingUnstructured(apiVersion, kind, namespace, name string) *unstructu
 			},
 		},
 	}
-
-	u.SetLabels(map[string]string{
-		addonapiv1alpha1.HostedManifestLocationLabelKey: constants.HostedManifestLocationHostingLabelValue,
+	u.SetAnnotations(map[string]string{
+		addonapiv1alpha1.HostedManifestLocationAnnotationKey: addonapiv1alpha1.HostedManifestLocationHostingValue,
 	})
 	return u
 }
 
 func NewHookJob(name, namespace string) *unstructured.Unstructured {
 	job := NewUnstructured("batch/v1", "Job", namespace, name)
-	job.SetLabels(map[string]string{addonapiv1alpha1.AddonPreDeleteHookLabelKey: ""})
+	job.SetAnnotations(map[string]string{addonapiv1alpha1.AddonPreDeleteHookAnnotationKey: ""})
 	return job
 }
 
 func NewHostedHookJob(name, namespace string) *unstructured.Unstructured {
 	job := NewUnstructured("batch/v1", "Job", namespace, name)
-	job.SetLabels(map[string]string{addonapiv1alpha1.AddonPreDeleteHookLabelKey: "",
-		addonapiv1alpha1.HostedManifestLocationLabelKey: constants.HostedManifestLocationHostingLabelValue,
-	})
+	job.SetAnnotations(map[string]string{addonapiv1alpha1.AddonPreDeleteHookAnnotationKey: "",
+		addonapiv1alpha1.HostedManifestLocationAnnotationKey: addonapiv1alpha1.HostedManifestLocationHostingValue})
 	return job
 }
 

--- a/pkg/addonmanager/constants/constants.go
+++ b/pkg/addonmanager/constants/constants.go
@@ -17,7 +17,7 @@ const (
 	AddonManifestApplied = "ManifestApplied"
 
 	// AddonManifestAppliedReasonWorkApplyFailed is the reason of condition AddonManifestApplied indicating
-	// the failuer of apply manifestwork of the manifests
+	// the failure of apply manifestwork of the manifests
 	AddonManifestAppliedReasonWorkApplyFailed = "ManifestWorkApplyFailed"
 
 	// AddonManifestAppliedReasonManifestsApplied is the reason of condition AddonManifestApplied indicating
@@ -36,15 +36,6 @@ const (
 	InstallModeBuiltinValueKey = "InstallMode"
 	InstallModeHosted          = "Hosted"
 	InstallModeDefault         = "Default"
-
-	// HostedManifestLocationManagedLabelValue indicates the manifest will be deployed on the managed cluster in Hosted
-	// mode, it is the default value of a manifest in Hosted mode
-	HostedManifestLocationManagedLabelValue = "managed"
-	// HostedManifestLocationHostingLabelValue indicates the manifest will be deployed on the hosting cluster in Hosted
-	// mode
-	HostedManifestLocationHostingLabelValue = "hosting"
-	// HostedManifestLocationNoneLabelValue indicates the manifest will not be deployed in Hosted mode
-	HostedManifestLocationNoneLabelValue = "none"
 
 	// HostingManifestFinalizer is the finalizer for an addon which has deployed manifests on the external
 	// hosting cluster in Hosted mode
@@ -97,17 +88,21 @@ func GetHostedModeInfo(annotations map[string]string) (string, string) {
 }
 
 // GetHostedManifestLocation returns the location of the manifest in Hosted mode, if it is invalid will return error
-func GetHostedManifestLocation(labels map[string]string) (string, bool, error) {
-	manifestLocation, ok := labels[addonv1alpha1.HostedManifestLocationLabelKey]
-	if !ok {
-		return "", false, nil
+func GetHostedManifestLocation(labels, annotations map[string]string) (string, bool, error) {
+	manifestLocation := annotations[addonv1alpha1.HostedManifestLocationAnnotationKey]
+
+	// TODO: deprecate HostedManifestLocationLabelKey in the future release
+	if manifestLocation == "" {
+		manifestLocation = labels[addonv1alpha1.HostedManifestLocationLabelKey]
 	}
 
 	switch manifestLocation {
-	case HostedManifestLocationManagedLabelValue,
-		HostedManifestLocationHostingLabelValue,
-		HostedManifestLocationNoneLabelValue:
+	case addonv1alpha1.HostedManifestLocationManagedValue,
+		addonv1alpha1.HostedManifestLocationHostingValue,
+		addonv1alpha1.HostedManifestLocationNoneValue:
 		return manifestLocation, true, nil
+	case "":
+		return "", false, nil
 	default:
 		return "", true, fmt.Errorf("not supported manifest location: %s", manifestLocation)
 	}

--- a/test/integration/agent_hook_deploy_test.go
+++ b/test/integration/agent_hook_deploy_test.go
@@ -29,9 +29,9 @@ const (
     "metadata": {
         "name": "test",
         "namespace": "default",
-        "labels": {
-            "open-cluster-management.io/addon-pre-delete":""
-        }
+		"annotations": {
+			"addon.open-cluster-management.io/addon-pre-delete":""
+		}
     },
     "spec": {
         "manualSelector": true,

--- a/test/integration/agent_hosting_deploy_test.go
+++ b/test/integration/agent_hosting_deploy_test.go
@@ -31,7 +31,7 @@ const (
 		"metadata": {
 			"name": "nginx-deployment",
 			"namespace": "default",
-			"labels": {
+			"annotations": {
 				"addon.open-cluster-management.io/hosted-manifest-location": "hosting"
 			}
 		},

--- a/test/integration/agent_hosting_hook_deploy_test.go
+++ b/test/integration/agent_hosting_hook_deploy_test.go
@@ -30,9 +30,9 @@ const (
     "metadata": {
         "name": "test",
         "namespace": "default",
-        "labels": {
-            "addon.open-cluster-management.io/hosted-manifest-location":"hosting",
-            "open-cluster-management.io/addon-pre-delete":""
+		"annotations": {
+            "addon.open-cluster-management.io/addon-pre-delete": "",
+			"addon.open-cluster-management.io/hosted-manifest-location": "hosting"
         }
     },
     "spec": {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1121,7 +1121,7 @@ k8s.io/utils/path
 k8s.io/utils/pointer
 k8s.io/utils/strings/slices
 k8s.io/utils/trace
-# open-cluster-management.io/api v0.9.1-0.20221212072517-d2016d321f33
+# open-cluster-management.io/api v0.9.1-0.20221222015712-61cf30907d02
 ## explicit; go 1.19
 open-cluster-management.io/api/addon/v1alpha1
 open-cluster-management.io/api/client/addon/clientset/versioned

--- a/vendor/open-cluster-management.io/api/addon/v1alpha1/types_managedclusteraddon.go
+++ b/vendor/open-cluster-management.io/api/addon/v1alpha1/types_managedclusteraddon.go
@@ -235,17 +235,38 @@ const (
 
 	// AddonPreDeleteHookLabelKey is the label key to identify that a resource manifest is used as pre-delete hook for an addon
 	// and should be created and deleted before the specified ManagedClusterAddon is deleted.
+	// Deprecated, and will be removed in the future release, please use annotation AddonPreDeleteHookAnnotationKey from v0.10.0.
 	AddonPreDeleteHookLabelKey = "open-cluster-management.io/addon-pre-delete"
+
+	// AddonPreDeleteHookAnnotationKey is the annotation key to identify that a resource manifest is used as pre-delete hook for an addon
+	// and should be created and deleted before the specified ManagedClusterAddon is deleted.
+	AddonPreDeleteHookAnnotationKey = "addon.open-cluster-management.io/addon-pre-delete"
 
 	// HostingClusterNameAnnotationKey is the annotation key for indicating the hosting cluster name, it should be set
 	// on ManagedClusterAddon resource only.
 	HostingClusterNameAnnotationKey = "addon.open-cluster-management.io/hosting-cluster-name"
 
-	// DeletionOrphanAnnotationKey is an annotation for the manifest of addin indicating that it will not be cleaned up
+	// DeletionOrphanAnnotationKey is an annotation for the manifest of addon indicating that it will not be cleaned up
 	// after the addon is deleted.
 	DeletionOrphanAnnotationKey = "addon.open-cluster-management.io/deletion-orphan"
 
-	// HostedManifestLocationLabelKey is the label key for indicating the cluster that the manifest should be deployed in Hosted
-	// mode.
+	// HostedManifestLocationLabelKey is the label key to identify where a resource manifest of addon agent
+	// with this label should be deployed in Hosted mode.
+	// Deprecated, will be removed in the future release, please use annotation HostedManifestLocationAnnotationKey from v0.10.0.
 	HostedManifestLocationLabelKey = "addon.open-cluster-management.io/hosted-manifest-location"
+
+	// HostedManifestLocationAnnotationKey is the annotation key to identify where a resource manifest of addon agent
+	// with this annotation should be deployed in Hosted mode.
+	HostedManifestLocationAnnotationKey = "addon.open-cluster-management.io/hosted-manifest-location"
+
+	// HostedManifestLocationManagedValue is a value of the annotation HostedManifestLocationAnnotationKey,
+	// indicates the manifest will be deployed on the managed cluster in Hosted mode,
+	// it is the default value of a manifest in Hosted mode.
+	HostedManifestLocationManagedValue = "managed"
+	// HostedManifestLocationHostingValue is a value of the annotation HostedManifestLocationAnnotationKey,
+	// indicates the manifest will be deployed on the hosting cluster in Hosted mode.
+	HostedManifestLocationHostingValue = "hosting"
+	// HostedManifestLocationNoneValue is a value of the annotation HostedManifestLocationAnnotationKey,,
+	// indicates the manifest will not be deployed in Hosted mode.
+	HostedManifestLocationNoneValue = "none"
 )


### PR DESCRIPTION
Signed-off-by: Zhiwei Yin <zyin@redhat.com>

deprecate the pre-delete and hostedLocation label, and replace by the annotation.
either the annotation or label can work in several release.
if the value in the annotation is different from that in the label, use the value in the annotation.
 the label will be removed in the future release.