### PR TITLE
Add the Helm default variable of hostingClusterCapabilities

### DIFF
--- a/pkg/addonfactory/addonfactory.go
+++ b/pkg/addonfactory/addonfactory.go
@@ -34,6 +34,7 @@ type AgentAddonFactory struct {
 	agentAddonOptions agent.AgentAddonOptions
 	// trimCRDDescription flag is used to trim the description of CRDs in manifestWork. disabled by default.
 	trimCRDDescription bool
+	hostingCluster     *clusterv1.ManagedCluster
 }
 
 // NewAgentAddonFactory builds an addonAgentFactory instance with addon name and fs.
@@ -112,6 +113,13 @@ func (f *AgentAddonFactory) WithTrimCRDDescription() *AgentAddonFactory {
 // WithConfigGVRs defines the addon supported configuration GroupVersionResource
 func (f *AgentAddonFactory) WithConfigGVRs(gvrs ...schema.GroupVersionResource) *AgentAddonFactory {
 	f.agentAddonOptions.SupportedConfigGVRs = append(f.agentAddonOptions.SupportedConfigGVRs, gvrs...)
+	return f
+}
+
+// WithHostingCluster defines the hosting cluster used in hosted mode. An AgentAddon may use this to provide
+// additional metadata.
+func (f *AgentAddonFactory) WithHostingCluster(cluster *clusterv1.ManagedCluster) *AgentAddonFactory {
+	f.hostingCluster = cluster
 	return f
 }
 

--- a/pkg/addonfactory/helper_test.go
+++ b/pkg/addonfactory/helper_test.go
@@ -35,7 +35,7 @@ func TestGetValuesFromAddonAnnotation(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			values, err := GetValuesFromAddonAnnotation(NewFakeManagedCluster("test"),
+			values, err := GetValuesFromAddonAnnotation(NewFakeManagedCluster("test", "1.10.1"),
 				NewFakeManagedClusterAddon("test", "test", "test", c.annotationValues))
 			if !c.expectedErr && err != nil {
 				t.Errorf("expected no error, bug got err %v", err)

--- a/pkg/addonfactory/template_agentaddon_test.go
+++ b/pkg/addonfactory/template_agentaddon_test.go
@@ -149,7 +149,7 @@ func TestTemplateAddon_Manifests(t *testing.T) {
 				c.expectedManagedKubeConfigSecret = fmt.Sprintf("%s-managed-kubeconfig", c.addonName)
 			}
 
-			cluster := NewFakeManagedCluster(c.clusterName)
+			cluster := NewFakeManagedCluster(c.clusterName, "1.10.1")
 			clusterAddon := NewFakeManagedClusterAddon(c.addonName, c.clusterName, c.installNamespace,
 				c.annotationConfig)
 

--- a/pkg/addonfactory/test_helper.go
+++ b/pkg/addonfactory/test_helper.go
@@ -6,13 +6,13 @@ import (
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
 )
 
-func NewFakeManagedCluster(name string) *clusterv1.ManagedCluster {
+func NewFakeManagedCluster(name string, k8sVersion string) *clusterv1.ManagedCluster {
 	return &clusterv1.ManagedCluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
 		},
 		Spec:   clusterv1.ManagedClusterSpec{},
-		Status: clusterv1.ManagedClusterStatus{Version: clusterv1.ManagedClusterVersion{Kubernetes: "1.10.1"}},
+		Status: clusterv1.ManagedClusterStatus{Version: clusterv1.ManagedClusterVersion{Kubernetes: k8sVersion}},
 	}
 }
 

--- a/pkg/addonfactory/testmanifests/chart/templates/namespace_hosted_mode.yaml
+++ b/pkg/addonfactory/testmanifests/chart/templates/namespace_hosted_mode.yaml
@@ -1,0 +1,8 @@
+{{- if .Values.hostingClusterCapabilities.KubeVersion.Version }}
+{{- if semverCompare "> 1.16.0" .Values.hostingClusterCapabilities.KubeVersion.Version }}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: "newer-k8s"
+{{- end }}
+{{- end }}


### PR DESCRIPTION
When deploying in hosted mode, the managed cluster's Kubernetes version
is always used in Helm charts conditionals such as:
{{- if semverCompare "< 1.16.0" .Capabilities.KubeVersion.Version }}

The hosted mode's version is required to guard against using Kubernetes API
features that aren't present on the cluster that the addon is being
deployed to not necessarily based on the target cluster that addon will
manage.

The new default Helm chart variable of hostingClusterCapabilities
is added so that in hosted mode, the hosted cluster's Kubernetes
version Kubernetes version is available. Unless the AgentAddonFactory
was built with the WithHostingCluster method, the
hostingClusterCapabilities will have empty values in it. The empty
values being returned by default make it easier to make if statements in
the Helm chart rather than guarding against a value not being present.

Relates:
https://issues.redhat.com/browse/ACM-3233
https://issues.redhat.com/browse/ACM-2923