### PR TITLE
Use golang:1.19 in the build Dockerfile

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18 AS builder
+FROM golang:1.19 AS builder
 ARG OS=linux
 ARG ARCH=amd64
 WORKDIR /go/src/open-cluster-management.io/addon-framework


### PR DESCRIPTION
Now that the project specifies Go 1.19, ensure that the builder provides that.