### PR TITLE
ci: push release image when there is a tag

### DIFF
--- a/.github/workflows/go-postsubmit.yml
+++ b/.github/workflows/go-postsubmit.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - release-*
   workflow_dispatch: {}
 
 env:

--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -16,8 +16,8 @@ defaults:
     working-directory: go/src/open-cluster-management.io/addon-framework
 
 jobs:
-  release:
-    name: release
+  env:
+    name: prepare release env
     runs-on: ubuntu-latest
     steps:
       - name: checkout code
@@ -31,13 +31,83 @@ jobs:
       - name: get major release version
         run: |
           echo "MAJOR_RELEASE_VERSION=${RELEASE_VERSION%.*}" >> $GITHUB_ENV
+          echo "TRIMED_RELEASE_VERSION=${RELEASE_VERSION#v}" >> $GITHUB_ENV
+    outputs:
+      MAJOR_RELEASE_VERSION: ${{ env.MAJOR_RELEASE_VERSION }}
+      RELEASE_VERSION: ${{ env.RELEASE_VERSION }}
+  images:
+    name: images
+    runs-on: ubuntu-latest
+    needs: [ env ]
+    strategy:
+      matrix:
+        arch: [ amd64, arm64 ]
+    steps:
+      - name: checkout code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 1
+          path: go/src/open-cluster-management.io/addon-framework
+      - name: install Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ env.GO_VERSION }}
+      - name: install imagebuilder
+        run: go install github.com/openshift/imagebuilder/cmd/imagebuilder@v1.2.3
+      - name: pull base image
+        run: docker pull registry.access.redhat.com/ubi8/ubi-minimal:latest --platform=linux/${{ matrix.arch }}
+      - name: images
+        run: |
+          IMAGE_TAG=${{ needs.env.outputs.RELEASE_VERSION }}-${{ matrix.arch }} \
+          IMAGE_BUILD_EXTRA_FLAGS="--build-arg OS=linux --build-arg ARCH=${{ matrix.arch }}" \
+            make image-addon-manager
+      - name: push image
+        run: |
+          echo ${{ secrets.DOCKER_PASSWORD }} | docker login quay.io --username ${{ secrets.DOCKER_USER }} --password-stdin
+          docker push quay.io/open-cluster-management/addon-manager:${{ needs.env.outputs.RELEASE_VERSION }}-${{ matrix.arch }}
+  image-manifest:
+    name: image manifest
+    runs-on: ubuntu-latest
+    needs: [ env, images ]
+    steps:
+      - name: checkout code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 1
+          path: go/src/open-cluster-management.io/addon-framework
+      - name: create
+        run: |
+          echo ${{ secrets.DOCKER_PASSWORD }} | docker login quay.io --username ${{ secrets.DOCKER_USER }} --password-stdin
+          docker manifest create quay.io/open-cluster-management/addon-manager:${{ needs.env.outputs.RELEASE_VERSION }} \
+            quay.io/open-cluster-management/addon-manager:${{ needs.env.outputs.RELEASE_VERSION }}-amd64 \
+            quay.io/open-cluster-management/addon-manager:${{ needs.env.outputs.RELEASE_VERSION }}-arm64
+      - name: annotate
+        run: |
+          docker manifest annotate quay.io/open-cluster-management/addon-manager:${{ needs.env.outputs.RELEASE_VERSION }} \
+            quay.io/open-cluster-management/addon-manager:${{ needs.env.outputs.RELEASE_VERSION }}-amd64 --arch amd64
+          docker manifest annotate quay.io/open-cluster-management/addon-manager:${{ needs.env.outputs.RELEASE_VERSION }} \
+            quay.io/open-cluster-management/addon-manager:${{ needs.env.outputs.RELEASE_VERSION }}-arm64 --arch arm64
+      - name: push
+        run: |
+          docker manifest push quay.io/open-cluster-management/addon-manager:${{ needs.env.outputs.RELEASE_VERSION }}
+  release:
+    name: release
+    runs-on: ubuntu-latest
+    needs: [ env, image-manifest ]
+    steps:
+      - name: checkout code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 1
+          path: go/src/open-cluster-management.io/addon-framework
       - name: generate changelog
         run: |
-          echo "# Work $RELEASE_VERSION" > /home/runner/work/changelog.txt
-          echo "- See the [CHANGELOG](https://github.com/open-cluster-management-io/addon-framework/blob/main/CHANGELOG/CHANGELOG-${MAJOR_RELEASE_VERSION}.md) for more details." >> /home/runner/addon-framework/changelog.txt
+          echo "# Addon Framework ${{ needs.env.outputs.RELEASE_VERSION }}" > /home/runner/work/changelog.txt
+          echo "- See the [CHANGELOG](https://github.com/open-cluster-management-io/addon-framework/blob/main/CHANGELOG/CHANGELOG-${{ needs.env.outputs.MAJOR_RELEASE_VERSION }}.md) for more details." >> /home/runner/work/changelog.txt
+          echo "- The released image is quay.io/open-cluster-management/addon-manager:${{ needs.env.outputs.RELEASE_VERSION }}" >> /home/runner/work/changelog.txt
       - name: publish release
         uses: softprops/action-gh-release@v0.1.5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          body_path: /home/runner/addon-framework/changelog.txt
+          body_path: /home/runner/work/changelog.txt


### PR DESCRIPTION
The post submit workflow will build and push the addon manager image with "latest" tag, only the main branch's code is the latest, stop other branches.