### PR TITLE
update mca config reference 

### DIFF
--- a/pkg/addonmanager/addontesting/helpers.go
+++ b/pkg/addonmanager/addontesting/helpers.go
@@ -153,6 +153,13 @@ func (b *clusterManagementAddonBuilder) WithPlacementStrategy(placements ...addo
 	return b
 }
 
+func (b *clusterManagementAddonBuilder) WithDefaultConfigReferences(
+	defaultConfigReferences ...addonapiv1alpha1.DefaultConfigReference,
+) *clusterManagementAddonBuilder {
+	b.clusterManagementAddOn.Status.DefaultConfigReferences = defaultConfigReferences
+	return b
+}
+
 func (b *clusterManagementAddonBuilder) WithInstallProgression(installProgressions ...addonapiv1alpha1.InstallProgression) *clusterManagementAddonBuilder {
 	b.clusterManagementAddOn.Status.InstallProgressions = installProgressions
 	return b

--- a/pkg/addonmanager/controllers/managementaddonconfig/controller.go
+++ b/pkg/addonmanager/controllers/managementaddonconfig/controller.go
@@ -266,7 +266,13 @@ func (c *clusterManagementAddonConfigController) getConfigSpecHash(gr addonapiv1
 		return "", nil
 	}
 
-	config, err := lister.Namespace(cr.Namespace).Get(cr.Name)
+	var config *unstructured.Unstructured
+	var err error
+	if cr.Namespace == "" {
+		config, err = lister.Get(cr.Name)
+	} else {
+		config, err = lister.Namespace(cr.Namespace).Get(cr.Name)
+	}
 	if errors.IsNotFound(err) {
 		return "", nil
 	}

--- a/pkg/manager/controllers/addonconfiguration/addon_configuration_reconciler.go
+++ b/pkg/manager/controllers/addonconfiguration/addon_configuration_reconciler.go
@@ -140,6 +140,7 @@ func (d *managedClusterAddonConfigurationReconciler) mergeAddonConfig(
 			if !equality.Semantic.DeepEqual(mergedConfigs[i].DesiredConfig, config.DesiredConfig) {
 				mergedConfigs[i].ConfigReferent = config.ConfigReferent
 				mergedConfigs[i].DesiredConfig = config.DesiredConfig.DeepCopy()
+				mergedConfigs[i].LastObservedGeneration = 0
 			}
 		}
 

--- a/pkg/manager/controllers/addonconfiguration/addon_configuration_reconciler_test.go
+++ b/pkg/manager/controllers/addonconfiguration/addon_configuration_reconciler_test.go
@@ -65,6 +65,7 @@ func TestAddonConfigReconcile(t *testing.T) {
 					DesiredConfig: &addonv1alpha1.ConfigSpecHash{
 						ConfigReferent: addonv1alpha1.ConfigReferent{Name: "test"},
 					},
+					LastObservedGeneration: 0,
 				}})
 			},
 		},
@@ -107,6 +108,7 @@ func TestAddonConfigReconcile(t *testing.T) {
 					DesiredConfig: &addonv1alpha1.ConfigSpecHash{
 						ConfigReferent: addonv1alpha1.ConfigReferent{Name: "test"},
 					},
+					LastObservedGeneration: 0,
 				}})
 				expectPatchConfigurationAction(t, actions[1], []addonv1alpha1.ConfigReference{{
 					ConfigGroupResource: addonv1alpha1.ConfigGroupResource{Group: "core", Resource: "Foo"},
@@ -114,6 +116,7 @@ func TestAddonConfigReconcile(t *testing.T) {
 					DesiredConfig: &addonv1alpha1.ConfigSpecHash{
 						ConfigReferent: addonv1alpha1.ConfigReferent{Name: "test1"},
 					},
+					LastObservedGeneration: 0,
 				}})
 			},
 		},
@@ -159,6 +162,7 @@ func TestAddonConfigReconcile(t *testing.T) {
 					DesiredConfig: &addonv1alpha1.ConfigSpecHash{
 						ConfigReferent: addonv1alpha1.ConfigReferent{Name: "test2"},
 					},
+					LastObservedGeneration: 0,
 				}})
 				expectPatchConfigurationAction(t, actions[1], []addonv1alpha1.ConfigReference{{
 					ConfigGroupResource: addonv1alpha1.ConfigGroupResource{Group: "core", Resource: "Foo"},
@@ -166,6 +170,7 @@ func TestAddonConfigReconcile(t *testing.T) {
 					DesiredConfig: &addonv1alpha1.ConfigSpecHash{
 						ConfigReferent: addonv1alpha1.ConfigReferent{Name: "test1"},
 					},
+					LastObservedGeneration: 0,
 				}})
 			},
 		},
@@ -179,6 +184,7 @@ func TestAddonConfigReconcile(t *testing.T) {
 						ConfigReferent: addonv1alpha1.ConfigReferent{Name: "test1"},
 						SpecHash:       "hash1",
 					},
+					LastObservedGeneration: 1,
 				}}),
 			},
 			placements: []runtime.Object{
@@ -214,6 +220,7 @@ func TestAddonConfigReconcile(t *testing.T) {
 						ConfigReferent: addonv1alpha1.ConfigReferent{Name: "test2"},
 						SpecHash:       "",
 					},
+					LastObservedGeneration: 0,
 				}})
 			},
 		},

--- a/pkg/manager/controllers/addonconfiguration/addon_configuration_reconciler_test.go
+++ b/pkg/manager/controllers/addonconfiguration/addon_configuration_reconciler_test.go
@@ -53,6 +53,12 @@ func TestAddonConfigReconcile(t *testing.T) {
 			clusterManagementAddon: addontesting.NewClusterManagementAddon("test", "", "").WithSupportedConfigs(addonv1alpha1.ConfigMeta{
 				ConfigGroupResource: addonv1alpha1.ConfigGroupResource{Group: "core", Resource: "Foo"},
 				DefaultConfig:       &addonv1alpha1.ConfigReferent{Name: "test"},
+			}).WithDefaultConfigReferences(addonv1alpha1.DefaultConfigReference{
+				ConfigGroupResource: v1alpha1.ConfigGroupResource{Group: "core", Resource: "Foo"},
+				DesiredConfig: &v1alpha1.ConfigSpecHash{
+					ConfigReferent: v1alpha1.ConfigReferent{Name: "test"},
+					SpecHash:       "hash",
+				},
 			}).Build(),
 			placements:         []runtime.Object{},
 			placementDecisions: []runtime.Object{},
@@ -64,6 +70,7 @@ func TestAddonConfigReconcile(t *testing.T) {
 					ConfigReferent:      addonv1alpha1.ConfigReferent{Name: "test"},
 					DesiredConfig: &addonv1alpha1.ConfigSpecHash{
 						ConfigReferent: addonv1alpha1.ConfigReferent{Name: "test"},
+						SpecHash:       "hash",
 					},
 					LastObservedGeneration: 0,
 				}})
@@ -93,11 +100,23 @@ func TestAddonConfigReconcile(t *testing.T) {
 			clusterManagementAddon: addontesting.NewClusterManagementAddon("test", "", "").WithSupportedConfigs(addonv1alpha1.ConfigMeta{
 				ConfigGroupResource: addonv1alpha1.ConfigGroupResource{Group: "core", Resource: "Foo"},
 				DefaultConfig:       &addonv1alpha1.ConfigReferent{Name: "test"},
-			}).WithPlacementStrategy(addonv1alpha1.PlacementStrategy{
+			}).WithDefaultConfigReferences(addonv1alpha1.DefaultConfigReference{
+				ConfigGroupResource: v1alpha1.ConfigGroupResource{Group: "core", Resource: "Foo"},
+				DesiredConfig: &v1alpha1.ConfigSpecHash{
+					ConfigReferent: v1alpha1.ConfigReferent{Name: "test"},
+					SpecHash:       "hash",
+				},
+			}).WithPlacementStrategy(addonv1alpha1.PlacementStrategy{}).WithInstallProgression(addonv1alpha1.InstallProgression{
 				PlacementRef: addonv1alpha1.PlacementRef{Name: "test-placement", Namespace: "default"},
-				Configs: []addonv1alpha1.AddOnConfig{v1alpha1.AddOnConfig{
-					ConfigGroupResource: v1alpha1.ConfigGroupResource{Group: "core", Resource: "Foo"},
-					ConfigReferent:      v1alpha1.ConfigReferent{Name: "test1"}}},
+				ConfigReferences: []addonv1alpha1.InstallConfigReference{
+					{
+						ConfigGroupResource: v1alpha1.ConfigGroupResource{Group: "core", Resource: "Foo"},
+						DesiredConfig: &v1alpha1.ConfigSpecHash{
+							ConfigReferent: v1alpha1.ConfigReferent{Name: "test1"},
+							SpecHash:       "hash1",
+						},
+					},
+				},
 			}).Build(),
 			validateAddonActions: func(t *testing.T, actions []clienttesting.Action) {
 				addontesting.AssertActions(t, actions, "patch", "patch")
@@ -107,6 +126,7 @@ func TestAddonConfigReconcile(t *testing.T) {
 					ConfigReferent:      addonv1alpha1.ConfigReferent{Name: "test"},
 					DesiredConfig: &addonv1alpha1.ConfigSpecHash{
 						ConfigReferent: addonv1alpha1.ConfigReferent{Name: "test"},
+						SpecHash:       "hash",
 					},
 					LastObservedGeneration: 0,
 				}})
@@ -115,6 +135,7 @@ func TestAddonConfigReconcile(t *testing.T) {
 					ConfigReferent:      addonv1alpha1.ConfigReferent{Name: "test1"},
 					DesiredConfig: &addonv1alpha1.ConfigSpecHash{
 						ConfigReferent: addonv1alpha1.ConfigReferent{Name: "test1"},
+						SpecHash:       "hash1",
 					},
 					LastObservedGeneration: 0,
 				}})
@@ -147,11 +168,23 @@ func TestAddonConfigReconcile(t *testing.T) {
 			clusterManagementAddon: addontesting.NewClusterManagementAddon("test", "", "").WithSupportedConfigs(addonv1alpha1.ConfigMeta{
 				ConfigGroupResource: addonv1alpha1.ConfigGroupResource{Group: "core", Resource: "Foo"},
 				DefaultConfig:       &addonv1alpha1.ConfigReferent{Name: "test"},
-			}).WithPlacementStrategy(addonv1alpha1.PlacementStrategy{
+			}).WithDefaultConfigReferences(addonv1alpha1.DefaultConfigReference{
+				ConfigGroupResource: v1alpha1.ConfigGroupResource{Group: "core", Resource: "Foo"},
+				DesiredConfig: &v1alpha1.ConfigSpecHash{
+					ConfigReferent: v1alpha1.ConfigReferent{Name: "test"},
+					SpecHash:       "hash",
+				},
+			}).WithPlacementStrategy(addonv1alpha1.PlacementStrategy{}).WithInstallProgression(addonv1alpha1.InstallProgression{
 				PlacementRef: addonv1alpha1.PlacementRef{Name: "test-placement", Namespace: "default"},
-				Configs: []addonv1alpha1.AddOnConfig{v1alpha1.AddOnConfig{
-					ConfigGroupResource: v1alpha1.ConfigGroupResource{Group: "core", Resource: "Foo"},
-					ConfigReferent:      v1alpha1.ConfigReferent{Name: "test1"}}},
+				ConfigReferences: []addonv1alpha1.InstallConfigReference{
+					{
+						ConfigGroupResource: v1alpha1.ConfigGroupResource{Group: "core", Resource: "Foo"},
+						DesiredConfig: &v1alpha1.ConfigSpecHash{
+							ConfigReferent: v1alpha1.ConfigReferent{Name: "test1"},
+							SpecHash:       "hash1",
+						},
+					},
+				},
 			}).Build(),
 			validateAddonActions: func(t *testing.T, actions []clienttesting.Action) {
 				addontesting.AssertActions(t, actions, "patch", "patch")
@@ -161,6 +194,7 @@ func TestAddonConfigReconcile(t *testing.T) {
 					ConfigReferent:      addonv1alpha1.ConfigReferent{Name: "test2"},
 					DesiredConfig: &addonv1alpha1.ConfigSpecHash{
 						ConfigReferent: addonv1alpha1.ConfigReferent{Name: "test2"},
+						SpecHash:       "",
 					},
 					LastObservedGeneration: 0,
 				}})
@@ -169,13 +203,70 @@ func TestAddonConfigReconcile(t *testing.T) {
 					ConfigReferent:      addonv1alpha1.ConfigReferent{Name: "test1"},
 					DesiredConfig: &addonv1alpha1.ConfigSpecHash{
 						ConfigReferent: addonv1alpha1.ConfigReferent{Name: "test1"},
+						SpecHash:       "hash1",
 					},
 					LastObservedGeneration: 0,
 				}})
 			},
 		},
 		{
-			name: "mca config change",
+			name: "config name/namespce change",
+			managedClusteraddon: []runtime.Object{
+				newManagedClusterAddon("test", "cluster1", []addonv1alpha1.AddOnConfig{}, []addonv1alpha1.ConfigReference{{
+					ConfigGroupResource: addonv1alpha1.ConfigGroupResource{Group: "core", Resource: "Foo"},
+					ConfigReferent:      addonv1alpha1.ConfigReferent{Name: "test1"},
+					DesiredConfig: &addonv1alpha1.ConfigSpecHash{
+						ConfigReferent: addonv1alpha1.ConfigReferent{Name: "test1"},
+						SpecHash:       "hash1",
+					},
+					LastObservedGeneration: 1,
+				}}),
+			},
+			placements: []runtime.Object{
+				&clusterv1beta1.Placement{ObjectMeta: metav1.ObjectMeta{Name: "test-placement", Namespace: "default"}},
+			},
+			placementDecisions: []runtime.Object{
+				&clusterv1beta1.PlacementDecision{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-placement",
+						Namespace: "default",
+						Labels:    map[string]string{clusterv1beta1.PlacementLabel: "test-placement"},
+					},
+					Status: clusterv1beta1.PlacementDecisionStatus{
+						Decisions: []clusterv1beta1.ClusterDecision{{ClusterName: "cluster1"}},
+					},
+				},
+			},
+			clusterManagementAddon: addontesting.NewClusterManagementAddon("test", "", "").WithSupportedConfigs(addonv1alpha1.ConfigMeta{
+				ConfigGroupResource: addonv1alpha1.ConfigGroupResource{Group: "core", Resource: "Foo"},
+				DefaultConfig:       &addonv1alpha1.ConfigReferent{Name: "test"},
+			}).WithPlacementStrategy(addonv1alpha1.PlacementStrategy{}).WithInstallProgression(addonv1alpha1.InstallProgression{
+				PlacementRef: addonv1alpha1.PlacementRef{Name: "test-placement", Namespace: "default"},
+				ConfigReferences: []addonv1alpha1.InstallConfigReference{
+					{
+						ConfigGroupResource: v1alpha1.ConfigGroupResource{Group: "core", Resource: "Foo"},
+						DesiredConfig: &v1alpha1.ConfigSpecHash{
+							ConfigReferent: v1alpha1.ConfigReferent{Name: "test2"},
+							SpecHash:       "hash2",
+						},
+					},
+				},
+			}).Build(),
+			validateAddonActions: func(t *testing.T, actions []clienttesting.Action) {
+				addontesting.AssertActions(t, actions, "patch")
+				expectPatchConfigurationAction(t, actions[0], []addonv1alpha1.ConfigReference{{
+					ConfigGroupResource: addonv1alpha1.ConfigGroupResource{Group: "core", Resource: "Foo"},
+					ConfigReferent:      addonv1alpha1.ConfigReferent{Name: "test2"},
+					DesiredConfig: &addonv1alpha1.ConfigSpecHash{
+						ConfigReferent: addonv1alpha1.ConfigReferent{Name: "test2"},
+						SpecHash:       "hash2",
+					},
+					LastObservedGeneration: 0,
+				}})
+			},
+		},
+		{
+			name: "config spec hash change",
 			managedClusteraddon: []runtime.Object{
 				newManagedClusterAddon("test", "cluster1", []addonv1alpha1.AddOnConfig{}, []addonv1alpha1.ConfigReference{{
 					ConfigGroupResource: addonv1alpha1.ConfigGroupResource{Group: "core", Resource: "Foo"},
@@ -209,18 +300,29 @@ func TestAddonConfigReconcile(t *testing.T) {
 				PlacementRef: addonv1alpha1.PlacementRef{Name: "test-placement", Namespace: "default"},
 				Configs: []addonv1alpha1.AddOnConfig{v1alpha1.AddOnConfig{
 					ConfigGroupResource: v1alpha1.ConfigGroupResource{Group: "core", Resource: "Foo"},
-					ConfigReferent:      v1alpha1.ConfigReferent{Name: "test2"}}},
+					ConfigReferent:      v1alpha1.ConfigReferent{Name: "test1"}}},
+			}).WithInstallProgression(addonv1alpha1.InstallProgression{
+				PlacementRef: addonv1alpha1.PlacementRef{Name: "test-placement", Namespace: "default"},
+				ConfigReferences: []addonv1alpha1.InstallConfigReference{
+					{
+						ConfigGroupResource: v1alpha1.ConfigGroupResource{Group: "core", Resource: "Foo"},
+						DesiredConfig: &v1alpha1.ConfigSpecHash{
+							ConfigReferent: v1alpha1.ConfigReferent{Name: "test1"},
+							SpecHash:       "hash1new",
+						},
+					},
+				},
 			}).Build(),
 			validateAddonActions: func(t *testing.T, actions []clienttesting.Action) {
 				addontesting.AssertActions(t, actions, "patch")
 				expectPatchConfigurationAction(t, actions[0], []addonv1alpha1.ConfigReference{{
 					ConfigGroupResource: addonv1alpha1.ConfigGroupResource{Group: "core", Resource: "Foo"},
-					ConfigReferent:      addonv1alpha1.ConfigReferent{Name: "test2"},
+					ConfigReferent:      addonv1alpha1.ConfigReferent{Name: "test1"},
 					DesiredConfig: &addonv1alpha1.ConfigSpecHash{
-						ConfigReferent: addonv1alpha1.ConfigReferent{Name: "test2"},
-						SpecHash:       "",
+						ConfigReferent: addonv1alpha1.ConfigReferent{Name: "test1"},
+						SpecHash:       "hash1new",
 					},
-					LastObservedGeneration: 0,
+					LastObservedGeneration: 1,
 				}})
 			},
 		},
@@ -234,6 +336,7 @@ func TestAddonConfigReconcile(t *testing.T) {
 						ConfigReferent: addonv1alpha1.ConfigReferent{Name: "test1"},
 						SpecHash:       "hash1",
 					},
+					LastObservedGeneration: 1,
 				}}),
 			},
 			placements: []runtime.Object{

--- a/pkg/manager/controllers/addonconfiguration/graph.go
+++ b/pkg/manager/controllers/addonconfiguration/graph.go
@@ -39,7 +39,7 @@ func (d addonConfigMap) copy() addonConfigMap {
 	return output
 }
 
-func newGraph(supportedConfigs []addonv1alpha1.ConfigMeta) *configurationGraph {
+func newGraph(supportedConfigs []addonv1alpha1.ConfigMeta, defaultConfigReferences []addonv1alpha1.DefaultConfigReference) *configurationGraph {
 	graph := &configurationGraph{
 		nodes: []*installStrategyNode{},
 		defaults: &installStrategyNode{
@@ -48,15 +48,26 @@ func newGraph(supportedConfigs []addonv1alpha1.ConfigMeta) *configurationGraph {
 		},
 	}
 
+	// init graph.defaults.desiredConfigs with supportedConfigs
 	for _, config := range supportedConfigs {
 		if config.DefaultConfig != nil {
 			graph.defaults.desiredConfigs[config.ConfigGroupResource] = addonv1alpha1.ConfigReference{
 				ConfigGroupResource: config.ConfigGroupResource,
-				ConfigReferent: addonv1alpha1.ConfigReferent{
-					Name:      config.DefaultConfig.Name,
-					Namespace: config.DefaultConfig.Namespace,
+				ConfigReferent:      *config.DefaultConfig,
+				DesiredConfig: &addonv1alpha1.ConfigSpecHash{
+					ConfigReferent: *config.DefaultConfig,
 				},
 			}
+		}
+	}
+	// copy the spechash from cma status defaultConfigReferences
+	for _, configRef := range defaultConfigReferences {
+		if configRef.DesiredConfig == nil {
+			continue
+		}
+		defaultsDesiredConfig, ok := graph.defaults.desiredConfigs[configRef.ConfigGroupResource]
+		if ok && (defaultsDesiredConfig.DesiredConfig.ConfigReferent == configRef.DesiredConfig.ConfigReferent) {
+			defaultsDesiredConfig.DesiredConfig.SpecHash = configRef.DesiredConfig.SpecHash
 		}
 	}
 
@@ -76,7 +87,8 @@ func (g *configurationGraph) addAddonNode(mca *addonv1alpha1.ManagedClusterAddOn
 }
 
 // addNode delete clusters on existing graph so the new configuration overrides the previous
-func (g *configurationGraph) addPlacementNode(configs []addonv1alpha1.AddOnConfig, clusters []string) {
+func (g *configurationGraph) addPlacementNode(configs []addonv1alpha1.AddOnConfig,
+	installConfigReference []addonv1alpha1.InstallConfigReference, clusters []string) {
 	node := &installStrategyNode{
 		desiredConfigs: g.defaults.desiredConfigs,
 		children:       map[string]*addonNode{},
@@ -90,7 +102,20 @@ func (g *configurationGraph) addPlacementNode(configs []addonv1alpha1.AddOnConfi
 			node.desiredConfigs[config.ConfigGroupResource] = addonv1alpha1.ConfigReference{
 				ConfigGroupResource: config.ConfigGroupResource,
 				ConfigReferent:      config.ConfigReferent,
+				DesiredConfig: &addonv1alpha1.ConfigSpecHash{
+					ConfigReferent: config.ConfigReferent,
+				},
 			}
+		}
+	}
+	// copy the spechash from cma status InstallProgressions
+	for _, configRef := range installConfigReference {
+		if configRef.DesiredConfig == nil {
+			continue
+		}
+		nodeDesiredConfig, ok := node.desiredConfigs[configRef.ConfigGroupResource]
+		if ok && (nodeDesiredConfig.DesiredConfig.ConfigReferent == configRef.DesiredConfig.ConfigReferent) {
+			nodeDesiredConfig.DesiredConfig.SpecHash = configRef.DesiredConfig.SpecHash
 		}
 	}
 
@@ -135,6 +160,19 @@ func (n *installStrategyNode) addNode(addon *addonv1alpha1.ManagedClusterAddOn) 
 			n.children[addon.Namespace].desiredConfigs[config.ConfigGroupResource] = addonv1alpha1.ConfigReference{
 				ConfigGroupResource: config.ConfigGroupResource,
 				ConfigReferent:      config.ConfigReferent,
+				DesiredConfig: &addonv1alpha1.ConfigSpecHash{
+					ConfigReferent: config.ConfigReferent,
+				},
+			}
+			// copy the spechash from mca status
+			for _, configRef := range addon.Status.ConfigReferences {
+				if configRef.DesiredConfig == nil {
+					continue
+				}
+				nodeDesiredConfig, ok := n.children[addon.Namespace].desiredConfigs[configRef.ConfigGroupResource]
+				if ok && (nodeDesiredConfig.DesiredConfig.ConfigReferent == configRef.DesiredConfig.ConfigReferent) {
+					nodeDesiredConfig.DesiredConfig.SpecHash = configRef.DesiredConfig.SpecHash
+				}
 			}
 		}
 	}

--- a/pkg/manager/controllers/addonconfiguration/graph_test.go
+++ b/pkg/manager/controllers/addonconfiguration/graph_test.go
@@ -16,11 +16,13 @@ type placementStrategy struct {
 
 func TestConfigurationGraph(t *testing.T) {
 	cases := []struct {
-		name                string
-		defaultConfigs      []addonv1alpha1.ConfigMeta
-		addons              []*addonv1alpha1.ManagedClusterAddOn
-		placementStrategies []placementStrategy
-		expected            []*addonNode
+		name                   string
+		defaultConfigs         []addonv1alpha1.ConfigMeta
+		defaultConfigReference []addonv1alpha1.DefaultConfigReference
+		addons                 []*addonv1alpha1.ManagedClusterAddOn
+		placementStrategies    []placementStrategy
+		installProgressions    []addonv1alpha1.InstallProgression
+		expected               []*addonNode
 	}{
 		{
 			name:     "no output",
@@ -33,6 +35,9 @@ func TestConfigurationGraph(t *testing.T) {
 				{ConfigGroupResource: addonv1alpha1.ConfigGroupResource{Group: "core", Resource: "Foo"},
 					DefaultConfig: &addonv1alpha1.ConfigReferent{Name: "test"}},
 			},
+			defaultConfigReference: []addonv1alpha1.DefaultConfigReference{
+				newDefaultConfigReference("core", "Foo", "test", "<core-foo-test-hash>"),
+			},
 			addons: []*addonv1alpha1.ManagedClusterAddOn{
 				addontesting.NewAddon("test", "cluster1"),
 				addontesting.NewAddon("test", "cluster2"),
@@ -43,6 +48,10 @@ func TestConfigurationGraph(t *testing.T) {
 						{Group: "core", Resource: "Foo"}: {
 							ConfigGroupResource: addonv1alpha1.ConfigGroupResource{Group: "core", Resource: "Foo"},
 							ConfigReferent:      addonv1alpha1.ConfigReferent{Name: "test"},
+							DesiredConfig: &addonv1alpha1.ConfigSpecHash{
+								ConfigReferent: addonv1alpha1.ConfigReferent{Name: "test"},
+								SpecHash:       "<core-foo-test-hash>",
+							},
 						},
 					},
 					mca: addontesting.NewAddon("test", "cluster1"),
@@ -52,6 +61,10 @@ func TestConfigurationGraph(t *testing.T) {
 						{Group: "core", Resource: "Foo"}: {
 							ConfigGroupResource: addonv1alpha1.ConfigGroupResource{Group: "core", Resource: "Foo"},
 							ConfigReferent:      addonv1alpha1.ConfigReferent{Name: "test"},
+							DesiredConfig: &addonv1alpha1.ConfigSpecHash{
+								ConfigReferent: addonv1alpha1.ConfigReferent{Name: "test"},
+								SpecHash:       "<core-foo-test-hash>",
+							},
 						},
 					},
 					mca: addontesting.NewAddon("test", "cluster2"),
@@ -65,6 +78,10 @@ func TestConfigurationGraph(t *testing.T) {
 					DefaultConfig: &addonv1alpha1.ConfigReferent{Name: "test"}},
 				{ConfigGroupResource: addonv1alpha1.ConfigGroupResource{Group: "core", Resource: "Foo"},
 					DefaultConfig: &addonv1alpha1.ConfigReferent{Name: "test"}},
+			},
+			defaultConfigReference: []addonv1alpha1.DefaultConfigReference{
+				newDefaultConfigReference("core", "Bar", "test", "<core-bar-test-hash>"),
+				newDefaultConfigReference("core", "Foo", "test", "<core-foo-test-hash>"),
 			},
 			addons: []*addonv1alpha1.ManagedClusterAddOn{
 				addontesting.NewAddon("test", "cluster1"),
@@ -83,16 +100,37 @@ func TestConfigurationGraph(t *testing.T) {
 						ConfigReferent: addonv1alpha1.ConfigReferent{Name: "test2"}},
 				}, clusters: []string{"cluster2"}},
 			},
+			installProgressions: []addonv1alpha1.InstallProgression{
+				{
+					ConfigReferences: []addonv1alpha1.InstallConfigReference{
+						newInstallConfigReference("core", "Bar", "test1", "<core-bar-test1-hash>"),
+					},
+				},
+				{
+					ConfigReferences: []addonv1alpha1.InstallConfigReference{
+						newInstallConfigReference("core", "Bar", "test2", "<core-bar-test2-hash>"),
+						newInstallConfigReference("core", "Foo", "test2", "<core-foo-test2-hash>"),
+					},
+				},
+			},
 			expected: []*addonNode{
 				{
 					desiredConfigs: map[addonv1alpha1.ConfigGroupResource]addonv1alpha1.ConfigReference{
 						{Group: "core", Resource: "Bar"}: {
 							ConfigGroupResource: addonv1alpha1.ConfigGroupResource{Group: "core", Resource: "Bar"},
 							ConfigReferent:      addonv1alpha1.ConfigReferent{Name: "test1"},
+							DesiredConfig: &addonv1alpha1.ConfigSpecHash{
+								ConfigReferent: addonv1alpha1.ConfigReferent{Name: "test1"},
+								SpecHash:       "<core-bar-test1-hash>",
+							},
 						},
 						{Group: "core", Resource: "Foo"}: {
 							ConfigGroupResource: addonv1alpha1.ConfigGroupResource{Group: "core", Resource: "Foo"},
 							ConfigReferent:      addonv1alpha1.ConfigReferent{Name: "test"},
+							DesiredConfig: &addonv1alpha1.ConfigSpecHash{
+								ConfigReferent: addonv1alpha1.ConfigReferent{Name: "test"},
+								SpecHash:       "<core-foo-test-hash>",
+							},
 						},
 					},
 					mca: addontesting.NewAddon("test", "cluster1"),
@@ -102,10 +140,18 @@ func TestConfigurationGraph(t *testing.T) {
 						{Group: "core", Resource: "Bar"}: {
 							ConfigGroupResource: addonv1alpha1.ConfigGroupResource{Group: "core", Resource: "Bar"},
 							ConfigReferent:      addonv1alpha1.ConfigReferent{Name: "test2"},
+							DesiredConfig: &addonv1alpha1.ConfigSpecHash{
+								ConfigReferent: addonv1alpha1.ConfigReferent{Name: "test2"},
+								SpecHash:       "<core-bar-test2-hash>",
+							},
 						},
 						{Group: "core", Resource: "Foo"}: {
 							ConfigGroupResource: addonv1alpha1.ConfigGroupResource{Group: "core", Resource: "Foo"},
 							ConfigReferent:      addonv1alpha1.ConfigReferent{Name: "test2"},
+							DesiredConfig: &addonv1alpha1.ConfigSpecHash{
+								ConfigReferent: addonv1alpha1.ConfigReferent{Name: "test2"},
+								SpecHash:       "<core-foo-test2-hash>",
+							},
 						},
 					},
 					mca: addontesting.NewAddon("test", "cluster2"),
@@ -115,10 +161,18 @@ func TestConfigurationGraph(t *testing.T) {
 						{Group: "core", Resource: "Bar"}: {
 							ConfigGroupResource: addonv1alpha1.ConfigGroupResource{Group: "core", Resource: "Bar"},
 							ConfigReferent:      addonv1alpha1.ConfigReferent{Name: "test"},
+							DesiredConfig: &addonv1alpha1.ConfigSpecHash{
+								ConfigReferent: addonv1alpha1.ConfigReferent{Name: "test"},
+								SpecHash:       "<core-bar-test-hash>",
+							},
 						},
 						{Group: "core", Resource: "Foo"}: {
 							ConfigGroupResource: addonv1alpha1.ConfigGroupResource{Group: "core", Resource: "Foo"},
 							ConfigReferent:      addonv1alpha1.ConfigReferent{Name: "test"},
+							DesiredConfig: &addonv1alpha1.ConfigSpecHash{
+								ConfigReferent: addonv1alpha1.ConfigReferent{Name: "test"},
+								SpecHash:       "<core-foo-test-hash>",
+							},
 						},
 					},
 					mca: addontesting.NewAddon("test", "cluster3"),
@@ -132,6 +186,10 @@ func TestConfigurationGraph(t *testing.T) {
 					DefaultConfig: &addonv1alpha1.ConfigReferent{Name: "test"}},
 				{ConfigGroupResource: addonv1alpha1.ConfigGroupResource{Group: "core", Resource: "Foo"},
 					DefaultConfig: &addonv1alpha1.ConfigReferent{Name: "test"}},
+			},
+			defaultConfigReference: []addonv1alpha1.DefaultConfigReference{
+				newDefaultConfigReference("core", "Bar", "test", "<core-bar-test-hash>"),
+				newDefaultConfigReference("core", "Foo", "test", "<core-foo-test-hash>"),
 			},
 			addons: []*addonv1alpha1.ManagedClusterAddOn{
 				newManagedClusterAddon("test", "cluster1", []addonv1alpha1.AddOnConfig{
@@ -153,16 +211,37 @@ func TestConfigurationGraph(t *testing.T) {
 						ConfigReferent: addonv1alpha1.ConfigReferent{Name: "test2"}},
 				}, clusters: []string{"cluster2"}},
 			},
+			installProgressions: []addonv1alpha1.InstallProgression{
+				{
+					ConfigReferences: []addonv1alpha1.InstallConfigReference{
+						newInstallConfigReference("core", "Foo", "test1", "<core-foo-test1-hash>"),
+					},
+				},
+				{
+					ConfigReferences: []addonv1alpha1.InstallConfigReference{
+						newInstallConfigReference("core", "Bar", "test2", "<core-bar-test2-hash>"),
+						newInstallConfigReference("core", "Foo", "test2", "<core-foo-test2-hash>"),
+					},
+				},
+			},
 			expected: []*addonNode{
 				{
 					desiredConfigs: map[addonv1alpha1.ConfigGroupResource]addonv1alpha1.ConfigReference{
 						{Group: "core", Resource: "Bar"}: {
 							ConfigGroupResource: addonv1alpha1.ConfigGroupResource{Group: "core", Resource: "Bar"},
 							ConfigReferent:      addonv1alpha1.ConfigReferent{Name: "test1"},
+							DesiredConfig: &addonv1alpha1.ConfigSpecHash{
+								ConfigReferent: addonv1alpha1.ConfigReferent{Name: "test1"},
+								SpecHash:       "",
+							},
 						},
 						{Group: "core", Resource: "Foo"}: {
 							ConfigGroupResource: addonv1alpha1.ConfigGroupResource{Group: "core", Resource: "Foo"},
 							ConfigReferent:      addonv1alpha1.ConfigReferent{Name: "test1"},
+							DesiredConfig: &addonv1alpha1.ConfigSpecHash{
+								ConfigReferent: addonv1alpha1.ConfigReferent{Name: "test1"},
+								SpecHash:       "<core-foo-test1-hash>",
+							},
 						},
 					},
 					mca: newManagedClusterAddon("test", "cluster1", []addonv1alpha1.AddOnConfig{
@@ -175,10 +254,18 @@ func TestConfigurationGraph(t *testing.T) {
 						{Group: "core", Resource: "Bar"}: {
 							ConfigGroupResource: addonv1alpha1.ConfigGroupResource{Group: "core", Resource: "Bar"},
 							ConfigReferent:      addonv1alpha1.ConfigReferent{Name: "test2"},
+							DesiredConfig: &addonv1alpha1.ConfigSpecHash{
+								ConfigReferent: addonv1alpha1.ConfigReferent{Name: "test2"},
+								SpecHash:       "<core-bar-test2-hash>",
+							},
 						},
 						{Group: "core", Resource: "Foo"}: {
 							ConfigGroupResource: addonv1alpha1.ConfigGroupResource{Group: "core", Resource: "Foo"},
 							ConfigReferent:      addonv1alpha1.ConfigReferent{Name: "test2"},
+							DesiredConfig: &addonv1alpha1.ConfigSpecHash{
+								ConfigReferent: addonv1alpha1.ConfigReferent{Name: "test2"},
+								SpecHash:       "<core-foo-test2-hash>",
+							},
 						},
 					},
 					mca: addontesting.NewAddon("test", "cluster2"),
@@ -188,10 +275,18 @@ func TestConfigurationGraph(t *testing.T) {
 						{Group: "core", Resource: "Bar"}: {
 							ConfigGroupResource: addonv1alpha1.ConfigGroupResource{Group: "core", Resource: "Bar"},
 							ConfigReferent:      addonv1alpha1.ConfigReferent{Name: "test"},
+							DesiredConfig: &addonv1alpha1.ConfigSpecHash{
+								ConfigReferent: addonv1alpha1.ConfigReferent{Name: "test"},
+								SpecHash:       "<core-bar-test-hash>",
+							},
 						},
 						{Group: "core", Resource: "Foo"}: {
 							ConfigGroupResource: addonv1alpha1.ConfigGroupResource{Group: "core", Resource: "Foo"},
 							ConfigReferent:      addonv1alpha1.ConfigReferent{Name: "test"},
+							DesiredConfig: &addonv1alpha1.ConfigSpecHash{
+								ConfigReferent: addonv1alpha1.ConfigReferent{Name: "test"},
+								SpecHash:       "<core-foo-test-hash>",
+							},
 						},
 					},
 					mca: addontesting.NewAddon("test", "cluster3"),
@@ -202,12 +297,12 @@ func TestConfigurationGraph(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			graph := newGraph(c.defaultConfigs)
+			graph := newGraph(c.defaultConfigs, c.defaultConfigReference)
 			for _, addon := range c.addons {
 				graph.addAddonNode(addon)
 			}
-			for _, strategy := range c.placementStrategies {
-				graph.addPlacementNode(strategy.configs, strategy.clusters)
+			for i, strategy := range c.placementStrategies {
+				graph.addPlacementNode(strategy.configs, c.installProgressions[i].ConfigReferences, strategy.clusters)
 			}
 
 			actual := graph.addonToUpdate()
@@ -234,5 +329,31 @@ func TestConfigurationGraph(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func newInstallConfigReference(group, resource, name, hash string) addonv1alpha1.InstallConfigReference {
+	return addonv1alpha1.InstallConfigReference{
+		ConfigGroupResource: addonv1alpha1.ConfigGroupResource{
+			Group:    group,
+			Resource: resource,
+		},
+		DesiredConfig: &addonv1alpha1.ConfigSpecHash{
+			ConfigReferent: addonv1alpha1.ConfigReferent{Name: name},
+			SpecHash:       hash,
+		},
+	}
+}
+
+func newDefaultConfigReference(group, resource, name, hash string) addonv1alpha1.DefaultConfigReference {
+	return addonv1alpha1.DefaultConfigReference{
+		ConfigGroupResource: addonv1alpha1.ConfigGroupResource{
+			Group:    group,
+			Resource: resource,
+		},
+		DesiredConfig: &addonv1alpha1.ConfigSpecHash{
+			ConfigReferent: addonv1alpha1.ConfigReferent{Name: name},
+			SpecHash:       hash,
+		},
 	}
 }

--- a/pkg/manager/controllers/addonconfiguration/graph_test.go
+++ b/pkg/manager/controllers/addonconfiguration/graph_test.go
@@ -302,7 +302,7 @@ func TestConfigurationGraph(t *testing.T) {
 				graph.addAddonNode(addon)
 			}
 			for i, strategy := range c.placementStrategies {
-				graph.addPlacementNode(strategy.configs, c.installProgressions[i].ConfigReferences, strategy.clusters)
+				graph.addPlacementNode(c.installProgressions[i].ConfigReferences, strategy.clusters)
 			}
 
 			actual := graph.addonToUpdate()

--- a/test/integration/addon_configs_test.go
+++ b/test/integration/addon_configs_test.go
@@ -128,14 +128,13 @@ var _ = ginkgo.Describe("AddConfigs", func() {
 				Namespace: configDefaultNamespace,
 				Name:      configDefaultName,
 			},
-			LastObservedGeneration: 1,
-			//			DesiredConfig: &addonapiv1alpha1.ConfigSpecHash{
-			//				ConfigReferent: addonapiv1alpha1.ConfigReferent{
-			//					Namespace: configDefaultNamespace,
-			//					Name:      configDefaultName,
-			//				},
-			//				SpecHash: addOnDefaultConfigSpecHash,
-			//			},
+			DesiredConfig: &addonapiv1alpha1.ConfigSpecHash{
+				ConfigReferent: addonapiv1alpha1.ConfigReferent{
+					Namespace: configDefaultNamespace,
+					Name:      configDefaultName,
+				},
+				SpecHash: addOnDefaultConfigSpecHash,
+			},
 		})
 	})
 
@@ -231,14 +230,13 @@ var _ = ginkgo.Describe("AddConfigs", func() {
 				Namespace: configDefaultNamespace,
 				Name:      "another-config",
 			},
-			LastObservedGeneration: 0,
-			//			DesiredConfig: &addonapiv1alpha1.ConfigSpecHash{
-			//				ConfigReferent: addonapiv1alpha1.ConfigReferent{
-			//					Namespace: configDefaultNamespace,
-			//					Name:      "another-config",
-			//				},
-			//				SpecHash: "",
-			//			},
+			DesiredConfig: &addonapiv1alpha1.ConfigSpecHash{
+				ConfigReferent: addonapiv1alpha1.ConfigReferent{
+					Namespace: configDefaultNamespace,
+					Name:      "another-config",
+				},
+				SpecHash: "",
+			},
 		})
 	})
 
@@ -320,14 +318,13 @@ var _ = ginkgo.Describe("AddConfigs", func() {
 				Namespace: addOnConfig.Namespace,
 				Name:      addOnConfig.Name,
 			},
-			LastObservedGeneration: 1,
-			//			DesiredConfig: &addonapiv1alpha1.ConfigSpecHash{
-			//				ConfigReferent: addonapiv1alpha1.ConfigReferent{
-			//					Namespace: addOnConfig.Namespace,
-			//					Name:      addOnConfig.Name,
-			//				},
-			//				SpecHash: addOnTest1ConfigSpecHash,
-			//			},
+			DesiredConfig: &addonapiv1alpha1.ConfigSpecHash{
+				ConfigReferent: addonapiv1alpha1.ConfigReferent{
+					Namespace: addOnConfig.Namespace,
+					Name:      addOnConfig.Name,
+				},
+				SpecHash: addOnTest1ConfigSpecHash,
+			},
 		})
 	})
 
@@ -393,14 +390,13 @@ var _ = ginkgo.Describe("AddConfigs", func() {
 				Namespace: addOnConfig.Namespace,
 				Name:      addOnConfig.Name,
 			},
-			LastObservedGeneration: 1,
-			//			DesiredConfig: &addonapiv1alpha1.ConfigSpecHash{
-			//				ConfigReferent: addonapiv1alpha1.ConfigReferent{
-			//					Namespace: addOnConfig.Namespace,
-			//					Name:      addOnConfig.Name,
-			//				},
-			//				SpecHash: addOnTest1ConfigSpecHash,
-			//			},
+			DesiredConfig: &addonapiv1alpha1.ConfigSpecHash{
+				ConfigReferent: addonapiv1alpha1.ConfigReferent{
+					Namespace: addOnConfig.Namespace,
+					Name:      addOnConfig.Name,
+				},
+				SpecHash: addOnTest1ConfigSpecHash,
+			},
 		})
 
 		addOnConfig, err = hubAddonClient.AddonV1alpha1().AddOnDeploymentConfigs(managedClusterName).Get(context.Background(), addOnConfig.Name, metav1.GetOptions{})
@@ -423,14 +419,13 @@ var _ = ginkgo.Describe("AddConfigs", func() {
 				Namespace: addOnConfig.Namespace,
 				Name:      addOnConfig.Name,
 			},
-			LastObservedGeneration: 2,
-			//			DesiredConfig: &addonapiv1alpha1.ConfigSpecHash{
-			//				ConfigReferent: addonapiv1alpha1.ConfigReferent{
-			//					Namespace: addOnConfig.Namespace,
-			//					Name:      addOnConfig.Name,
-			//				},
-			//				SpecHash: addOnTest2ConfigSpecHash,
-			//			},
+			DesiredConfig: &addonapiv1alpha1.ConfigSpecHash{
+				ConfigReferent: addonapiv1alpha1.ConfigReferent{
+					Namespace: addOnConfig.Namespace,
+					Name:      addOnConfig.Name,
+				},
+				SpecHash: addOnTest2ConfigSpecHash,
+			},
 		})
 	})
 
@@ -503,14 +498,13 @@ var _ = ginkgo.Describe("AddConfigs", func() {
 				Namespace: addOnConfig.Namespace,
 				Name:      addOnConfig.Name,
 			},
-			LastObservedGeneration: 1,
-			//			DesiredConfig: &addonapiv1alpha1.ConfigSpecHash{
-			//				ConfigReferent: addonapiv1alpha1.ConfigReferent{
-			//					Namespace: addOnConfig.Namespace,
-			//					Name:      addOnConfig.Name,
-			//				},
-			//				SpecHash: "",
-			//			},
+			DesiredConfig: &addonapiv1alpha1.ConfigSpecHash{
+				ConfigReferent: addonapiv1alpha1.ConfigReferent{
+					Namespace: addOnConfig.Namespace,
+					Name:      addOnConfig.Name,
+				},
+				SpecHash: "",
+			},
 		})
 	})
 })

--- a/test/integration/addon_configs_test.go
+++ b/test/integration/addon_configs_test.go
@@ -128,6 +128,7 @@ var _ = ginkgo.Describe("AddConfigs", func() {
 				Namespace: configDefaultNamespace,
 				Name:      configDefaultName,
 			},
+			LastObservedGeneration: 1,
 			DesiredConfig: &addonapiv1alpha1.ConfigSpecHash{
 				ConfigReferent: addonapiv1alpha1.ConfigReferent{
 					Namespace: configDefaultNamespace,
@@ -230,6 +231,7 @@ var _ = ginkgo.Describe("AddConfigs", func() {
 				Namespace: configDefaultNamespace,
 				Name:      "another-config",
 			},
+			LastObservedGeneration: 0,
 			DesiredConfig: &addonapiv1alpha1.ConfigSpecHash{
 				ConfigReferent: addonapiv1alpha1.ConfigReferent{
 					Namespace: configDefaultNamespace,
@@ -318,6 +320,7 @@ var _ = ginkgo.Describe("AddConfigs", func() {
 				Namespace: addOnConfig.Namespace,
 				Name:      addOnConfig.Name,
 			},
+			LastObservedGeneration: 1,
 			DesiredConfig: &addonapiv1alpha1.ConfigSpecHash{
 				ConfigReferent: addonapiv1alpha1.ConfigReferent{
 					Namespace: addOnConfig.Namespace,
@@ -390,6 +393,7 @@ var _ = ginkgo.Describe("AddConfigs", func() {
 				Namespace: addOnConfig.Namespace,
 				Name:      addOnConfig.Name,
 			},
+			LastObservedGeneration: 1,
 			DesiredConfig: &addonapiv1alpha1.ConfigSpecHash{
 				ConfigReferent: addonapiv1alpha1.ConfigReferent{
 					Namespace: addOnConfig.Namespace,
@@ -419,6 +423,7 @@ var _ = ginkgo.Describe("AddConfigs", func() {
 				Namespace: addOnConfig.Namespace,
 				Name:      addOnConfig.Name,
 			},
+			LastObservedGeneration: 2,
 			DesiredConfig: &addonapiv1alpha1.ConfigSpecHash{
 				ConfigReferent: addonapiv1alpha1.ConfigReferent{
 					Namespace: addOnConfig.Namespace,
@@ -498,6 +503,7 @@ var _ = ginkgo.Describe("AddConfigs", func() {
 				Namespace: addOnConfig.Namespace,
 				Name:      addOnConfig.Name,
 			},
+			LastObservedGeneration: 0,
 			DesiredConfig: &addonapiv1alpha1.ConfigSpecHash{
 				ConfigReferent: addonapiv1alpha1.ConfigReferent{
 					Namespace: addOnConfig.Namespace,

--- a/test/integration/addon_configs_test.go
+++ b/test/integration/addon_configs_test.go
@@ -503,7 +503,7 @@ var _ = ginkgo.Describe("AddConfigs", func() {
 				Namespace: addOnConfig.Namespace,
 				Name:      addOnConfig.Name,
 			},
-			LastObservedGeneration: 0,
+			LastObservedGeneration: 1,
 			DesiredConfig: &addonapiv1alpha1.ConfigSpecHash{
 				ConfigReferent: addonapiv1alpha1.ConfigReferent{
 					Namespace: addOnConfig.Namespace,


### PR DESCRIPTION
this PR is to update the config reference in mca status, it is part of the implementation of rollout strategy

- add manager generate config references for each mca, based on cma.spec. mca.spec.
- add manager sync spec hash from cma status to mca status config reference. 
- add framework update spec hash of the mca.spec.configs in mca status config reference.

Ref: https://github.com/open-cluster-management-io/OCM/issues/114