### PR TITLE
Make manifestWork UpdateStrategy configurable through AgentAddonOptions

### DIFF
--- a/pkg/addonmanager/controllers/agentdeploy/utils.go
+++ b/pkg/addonmanager/controllers/agentdeploy/utils.go
@@ -474,26 +474,29 @@ func newAddonWorkObjectMeta(namePrefix, addonName, addonNamespace, workNamespace
 }
 
 func getManifestConfigOption(agentAddon agent.AgentAddon) []workapiv1.ManifestConfigOption {
-	if agentAddon.GetAgentAddonOptions().HealthProber == nil {
-		return nil
-	}
-
-	if agentAddon.GetAgentAddonOptions().HealthProber.Type != agent.HealthProberTypeWork {
-		return nil
-	}
-
-	if agentAddon.GetAgentAddonOptions().HealthProber.WorkProber == nil {
-		return nil
-	}
-
 	manifestConfigs := []workapiv1.ManifestConfigOption{}
-	probeRules := agentAddon.GetAgentAddonOptions().HealthProber.WorkProber.ProbeFields
-	for _, rule := range probeRules {
-		manifestConfigs = append(manifestConfigs, workapiv1.ManifestConfigOption{
-			ResourceIdentifier: rule.ResourceIdentifier,
-			FeedbackRules:      rule.ProbeRules,
-		})
+
+	if agentAddon.GetAgentAddonOptions().HealthProber != nil &&
+		agentAddon.GetAgentAddonOptions().HealthProber.Type == agent.HealthProberTypeWork &&
+		agentAddon.GetAgentAddonOptions().HealthProber.WorkProber != nil {
+		probeRules := agentAddon.GetAgentAddonOptions().HealthProber.WorkProber.ProbeFields
+		for _, rule := range probeRules {
+			manifestConfigs = append(manifestConfigs, workapiv1.ManifestConfigOption{
+				ResourceIdentifier: rule.ResourceIdentifier,
+				FeedbackRules:      rule.ProbeRules,
+			})
+		}
 	}
+
+	if updaters := agentAddon.GetAgentAddonOptions().Updaters; updaters != nil {
+		for _, updater := range updaters {
+			manifestConfigs = append(manifestConfigs, workapiv1.ManifestConfigOption{
+				ResourceIdentifier: updater.ResourceIdentifier,
+				UpdateStrategy:     &updater.UpdateStrategy,
+			})
+		}
+	}
+
 	return manifestConfigs
 }
 

--- a/pkg/agent/inteface.go
+++ b/pkg/agent/inteface.go
@@ -55,6 +55,11 @@ type AgentAddonOptions struct {
 	// +optional
 	InstallStrategy *InstallStrategy
 
+	// Updaters select a set of resources and define the strategies to update them.
+	// UpdateStrategy is Update if no Updater is defined for a resource.
+	// +optional
+	Updaters []Updater
+
 	// HealthProber defines how is the healthiness status of the ManagedClusterAddon probed.
 	// Note that the prescribed prober type here only applies to the automatically installed
 	// addons configured via InstallStrategy.
@@ -137,6 +142,14 @@ func (s *InstallStrategy) GetManagedClusterFilter() func(cluster *clusterv1.Mana
 	return s.managedClusterFilter
 }
 
+type Updater struct {
+	// ResourceIdentifier sets what resources the strategy applies to
+	ResourceIdentifier workapiv1.ResourceIdentifier
+
+	// UpdateStrategy defines the strategy used to update the manifests.
+	UpdateStrategy workapiv1.UpdateStrategy
+}
+
 type HealthProber struct {
 	Type HealthProberType
 
@@ -155,7 +168,7 @@ type WorkHealthProber struct {
 
 // ProbeField defines the field of a resource to be probed
 type ProbeField struct {
-	// ResourceIdentifier sets what resource shoule be probed
+	// ResourceIdentifier sets what resource should be probed
 	ResourceIdentifier workapiv1.ResourceIdentifier
 
 	// ProbeRules sets the rules to probe the field


### PR DESCRIPTION
It makes possible to specify that "create only" or "server side apply" is to be used for some manifests containing configuration data so that regular changes made by users do not get overwritten by an update of the resource pushed by the addon.

fixes: #173 