### PR TITLE
only enable install strategy and update install progression when addon is managed by addon-manager

### DIFF
--- a/pkg/manager/controllers/addonmanagement/controller.go
+++ b/pkg/manager/controllers/addonmanagement/controller.go
@@ -44,6 +44,7 @@ func NewAddonManagementController(
 	clusterManagementAddonInformers addoninformerv1alpha1.ClusterManagementAddOnInformer,
 	placementInformer clusterinformersv1beta1.PlacementInformer,
 	placementDecisionInformer clusterinformersv1beta1.PlacementDecisionInformer,
+	addonFilterFunc factory.EventFilterFunc,
 ) factory.Controller {
 	c := &addonManagementController{
 		addonClient:                   addonClient,
@@ -56,6 +57,7 @@ func NewAddonManagementController(
 				placementDecisionLister:    placementDecisionInformer.Lister(),
 				placementLister:            placementInformer.Lister(),
 				managedClusterAddonIndexer: addonInformers.Informer().GetIndexer(),
+				addonFilterFunc:            addonFilterFunc,
 			},
 		},
 	}

--- a/pkg/manager/controllers/addonmanagement/controller_test.go
+++ b/pkg/manager/controllers/addonmanagement/controller_test.go
@@ -10,7 +10,9 @@ import (
 	clienttesting "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/cache"
 	"open-cluster-management.io/addon-framework/pkg/addonmanager/addontesting"
+	"open-cluster-management.io/addon-framework/pkg/agent"
 	"open-cluster-management.io/addon-framework/pkg/index"
+	"open-cluster-management.io/addon-framework/pkg/utils"
 	addonv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
 	fakeaddon "open-cluster-management.io/api/client/addon/clientset/versioned/fake"
 	addoninformers "open-cluster-management.io/api/client/addon/informers/externalversions"
@@ -255,6 +257,7 @@ func TestAddonInstallReconcile(t *testing.T) {
 				placementLister:            clusterInformers.Cluster().V1beta1().Placements().Lister(),
 				placementDecisionLister:    clusterInformers.Cluster().V1beta1().PlacementDecisions().Lister(),
 				managedClusterAddonIndexer: addonInformers.Addon().V1alpha1().ManagedClusterAddOns().Informer().GetIndexer(),
+				addonFilterFunc:            utils.ManagedBySelf(map[string]agent.AgentAddon{"test": nil}),
 			}
 
 			_, _, err = reconcile.reconcile(context.TODO(), c.clusterManagementAddon)

--- a/pkg/manager/controllers/managementaddoninstallprogression/controller_test.go
+++ b/pkg/manager/controllers/managementaddoninstallprogression/controller_test.go
@@ -9,6 +9,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	clienttesting "k8s.io/client-go/testing"
 	"open-cluster-management.io/addon-framework/pkg/addonmanager/addontesting"
+	"open-cluster-management.io/addon-framework/pkg/agent"
+	"open-cluster-management.io/addon-framework/pkg/utils"
 	"open-cluster-management.io/api/addon/v1alpha1"
 	addonapiv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
 	fakeaddon "open-cluster-management.io/api/client/addon/clientset/versioned/fake"
@@ -238,6 +240,7 @@ func TestReconcile(t *testing.T) {
 				addonClient:                  fakeAddonClient,
 				clusterManagementAddonLister: addonInformers.Addon().V1alpha1().ClusterManagementAddOns().Lister(),
 				managedClusterAddonLister:    addonInformers.Addon().V1alpha1().ManagedClusterAddOns().Lister(),
+				addonFilterFunc:              utils.ManagedBySelf(map[string]agent.AgentAddon{"test": nil}),
 			}
 
 			syncContext := addontesting.NewFakeSyncContext(t)

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -78,6 +78,7 @@ func RunManager(ctx context.Context, kubeConfig *rest.Config) error {
 		addonInformerFactory.Addon().V1alpha1().ClusterManagementAddOns(),
 		clusterInformerFactory.Cluster().V1beta1().Placements(),
 		clusterInformerFactory.Cluster().V1beta1().PlacementDecisions(),
+		utils.ManagedByAddonManager,
 	)
 
 	addonConfigurationController := addonconfiguration.NewAddonConfigurationController(
@@ -108,6 +109,7 @@ func RunManager(ctx context.Context, kubeConfig *rest.Config) error {
 		addonClient,
 		addonInformerFactory.Addon().V1alpha1().ManagedClusterAddOns(),
 		addonInformerFactory.Addon().V1alpha1().ClusterManagementAddOns(),
+		utils.ManagedByAddonManager,
 	)
 
 	go addonManagementController.Run(ctx, 2)


### PR DESCRIPTION
This PR tried to fix: 
1 When add-on cma is managed by self, cma defined install strategy should not work, since it has conflicted with hard code WithInstallStrategy().
2 When add-on cma is managed by self, cma should not list installprogression in status.