### PR TITLE
Disable post commit job for pushing addon manager image

### DIFF
--- a/.github/workflows/go-postsubmit.yml
+++ b/.github/workflows/go-postsubmit.yml
@@ -40,11 +40,11 @@ jobs:
         run: |
           IMAGE_TAG=latest-${{ matrix.arch }} \
           IMAGE_BUILD_EXTRA_FLAGS="--build-arg OS=linux --build-arg ARCH=${{ matrix.arch }}" \
-            make image-addon-manager
+            make image-addon-examples
       - name: push
         run: |
           echo ${{ secrets.DOCKER_PASSWORD }} | docker login quay.io --username ${{ secrets.DOCKER_USER }} --password-stdin
-          docker push quay.io/open-cluster-management/addon-manager:latest-${{ matrix.arch }}
+          docker push quay.io/open-cluster-management/addon-examples:latest-${{ matrix.arch }}
   image-manifest:
     name: image manifest
     runs-on: ubuntu-latest
@@ -58,15 +58,15 @@ jobs:
       - name: create
         run: |
           echo ${{ secrets.DOCKER_PASSWORD }} | docker login quay.io --username ${{ secrets.DOCKER_USER }} --password-stdin
-          docker manifest create quay.io/open-cluster-management/addon-manager:latest \
-            quay.io/open-cluster-management/addon-manager:latest-amd64 \
-            quay.io/open-cluster-management/addon-manager:latest-arm64
+          docker manifest create quay.io/open-cluster-management/addon-examples:latest \
+            quay.io/open-cluster-management/addon-examples:latest-amd64 \
+            quay.io/open-cluster-management/addon-examples:latest-arm64
       - name: annotate
         run: |
-          docker manifest annotate quay.io/open-cluster-management/addon-manager:latest \
-            quay.io/open-cluster-management/addon-manager:latest-amd64 --arch amd64
-          docker manifest annotate quay.io/open-cluster-management/addon-manager:latest \
-            quay.io/open-cluster-management/addon-manager:latest-arm64 --arch arm64
+          docker manifest annotate quay.io/open-cluster-management/addon-examples:latest \
+            quay.io/open-cluster-management/addon-examples:latest-amd64 --arch amd64
+          docker manifest annotate quay.io/open-cluster-management/addon-examples:latest \
+            quay.io/open-cluster-management/addon-examples:latest-arm64 --arch arm64
       - name: push
         run: |
-          docker manifest push quay.io/open-cluster-management/addon-manager:latest
+          docker manifest push quay.io/open-cluster-management/addon-examples:latest

--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -60,11 +60,11 @@ jobs:
         run: |
           IMAGE_TAG=${{ needs.env.outputs.RELEASE_VERSION }}-${{ matrix.arch }} \
           IMAGE_BUILD_EXTRA_FLAGS="--build-arg OS=linux --build-arg ARCH=${{ matrix.arch }}" \
-            make image-addon-manager
+            make image-addon-examples
       - name: push image
         run: |
           echo ${{ secrets.DOCKER_PASSWORD }} | docker login quay.io --username ${{ secrets.DOCKER_USER }} --password-stdin
-          docker push quay.io/open-cluster-management/addon-manager:${{ needs.env.outputs.RELEASE_VERSION }}-${{ matrix.arch }}
+          docker push quay.io/open-cluster-management/addon-examples:${{ needs.env.outputs.RELEASE_VERSION }}-${{ matrix.arch }}
   image-manifest:
     name: image manifest
     runs-on: ubuntu-latest
@@ -78,18 +78,18 @@ jobs:
       - name: create
         run: |
           echo ${{ secrets.DOCKER_PASSWORD }} | docker login quay.io --username ${{ secrets.DOCKER_USER }} --password-stdin
-          docker manifest create quay.io/open-cluster-management/addon-manager:${{ needs.env.outputs.RELEASE_VERSION }} \
-            quay.io/open-cluster-management/addon-manager:${{ needs.env.outputs.RELEASE_VERSION }}-amd64 \
-            quay.io/open-cluster-management/addon-manager:${{ needs.env.outputs.RELEASE_VERSION }}-arm64
+          docker manifest create quay.io/open-cluster-management/addon-examples:${{ needs.env.outputs.RELEASE_VERSION }} \
+            quay.io/open-cluster-management/addon-examples:${{ needs.env.outputs.RELEASE_VERSION }}-amd64 \
+            quay.io/open-cluster-management/addon-examples:${{ needs.env.outputs.RELEASE_VERSION }}-arm64
       - name: annotate
         run: |
-          docker manifest annotate quay.io/open-cluster-management/addon-manager:${{ needs.env.outputs.RELEASE_VERSION }} \
-            quay.io/open-cluster-management/addon-manager:${{ needs.env.outputs.RELEASE_VERSION }}-amd64 --arch amd64
-          docker manifest annotate quay.io/open-cluster-management/addon-manager:${{ needs.env.outputs.RELEASE_VERSION }} \
-            quay.io/open-cluster-management/addon-manager:${{ needs.env.outputs.RELEASE_VERSION }}-arm64 --arch arm64
+          docker manifest annotate quay.io/open-cluster-management/addon-examples:${{ needs.env.outputs.RELEASE_VERSION }} \
+            quay.io/open-cluster-management/addon-examples:${{ needs.env.outputs.RELEASE_VERSION }}-amd64 --arch amd64
+          docker manifest annotate quay.io/open-cluster-management/addon-examples:${{ needs.env.outputs.RELEASE_VERSION }} \
+            quay.io/open-cluster-management/addon-examples:${{ needs.env.outputs.RELEASE_VERSION }}-arm64 --arch arm64
       - name: push
         run: |
-          docker manifest push quay.io/open-cluster-management/addon-manager:${{ needs.env.outputs.RELEASE_VERSION }}
+          docker manifest push quay.io/open-cluster-management/addon-examples:${{ needs.env.outputs.RELEASE_VERSION }}
   release:
     name: release
     runs-on: ubuntu-latest
@@ -104,7 +104,7 @@ jobs:
         run: |
           echo "# Addon Framework ${{ needs.env.outputs.RELEASE_VERSION }}" > /home/runner/work/changelog.txt
           echo "- See the [CHANGELOG](https://github.com/open-cluster-management-io/addon-framework/blob/main/CHANGELOG/CHANGELOG-${{ needs.env.outputs.MAJOR_RELEASE_VERSION }}.md) for more details." >> /home/runner/work/changelog.txt
-          echo "- The released image is quay.io/open-cluster-management/addon-manager:${{ needs.env.outputs.RELEASE_VERSION }}" >> /home/runner/work/changelog.txt
+          echo "- The released image is quay.io/open-cluster-management/addon-examples:${{ needs.env.outputs.RELEASE_VERSION }}" >> /home/runner/work/changelog.txt
       - name: publish release
         uses: softprops/action-gh-release@v0.1.5
         env:

--- a/pkg/utils/helpers.go
+++ b/pkg/utils/helpers.go
@@ -24,7 +24,6 @@ import (
 	addonv1alpha1client "open-cluster-management.io/api/client/addon/clientset/versioned"
 
 	"open-cluster-management.io/addon-framework/pkg/agent"
-	"open-cluster-management.io/addon-framework/pkg/basecontroller/factory"
 )
 
 func MergeRelatedObjects(modified *bool, objs *[]addonapiv1alpha1.ObjectReference, obj addonapiv1alpha1.ObjectReference) {
@@ -307,7 +306,7 @@ func ManagedByAddonManager(obj interface{}) bool {
 	return value == addonapiv1alpha1.AddonLifecycleAddonManagerAnnotationValue
 }
 
-func ManagedBySelf(agentAddons map[string]agent.AgentAddon) factory.EventFilterFunc {
+func ManagedBySelf(agentAddons map[string]agent.AgentAddon) func(obj interface{}) bool {
 	return func(obj interface{}) bool {
 		accessor, _ := meta.Accessor(obj)
 		if _, ok := agentAddons[accessor.GetName()]; !ok {
@@ -329,7 +328,7 @@ func ManagedBySelf(agentAddons map[string]agent.AgentAddon) factory.EventFilterF
 	}
 }
 
-func FilterByAddonName(agentAddons map[string]agent.AgentAddon) factory.EventFilterFunc {
+func FilterByAddonName(agentAddons map[string]agent.AgentAddon) func(obj interface{}) bool {
 	return func(obj interface{}) bool {
 		accessor, _ := meta.Accessor(obj)
 		_, ok := agentAddons[accessor.GetName()]


### PR DESCRIPTION
We will move Addon-manager from this repo to ocm repo, so disable post commit job for pushing addon manager image, but enable pushing addon-examples image(will be used in ocm e2e tests)

related issues：
- https://github.com/open-cluster-management-io/ocm/pull/196