### PR TITLE
make the agent deploy controller watch the managed cluster

### DIFF
--- a/cmd/example/helloworld_helm/main.go
+++ b/cmd/example/helloworld_helm/main.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	utilrand "k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/client-go/kubernetes"
@@ -18,6 +19,7 @@ import (
 	logs "k8s.io/component-base/logs/api/v1"
 	"k8s.io/klog/v2"
 	addonv1alpha1client "open-cluster-management.io/api/client/addon/clientset/versioned"
+	clusterv1 "open-cluster-management.io/api/cluster/v1"
 
 	"open-cluster-management.io/addon-framework/examples/helloworld"
 	"open-cluster-management.io/addon-framework/examples/helloworld_agent"
@@ -105,6 +107,9 @@ func runController(ctx context.Context, kubeConfig *rest.Config) error {
 			schema.GroupVersionResource{Version: "v1", Resource: "configmaps"},
 			utils.AddOnDeploymentConfigGVR,
 		).
+		WithAgentDeployTriggerClusterFilter(func(old, new *clusterv1.ManagedCluster) bool {
+			return !equality.Semantic.DeepEqual(old.Annotations, new.Annotations)
+		}).
 		WithGetValuesFuncs(
 			helloworld_helm.GetDefaultValues,
 			addonfactory.GetAddOnDeploymentConfigValues(

--- a/pkg/addonfactory/addonfactory.go
+++ b/pkg/addonfactory/addonfactory.go
@@ -124,6 +124,24 @@ func (f *AgentAddonFactory) WithHostingCluster(cluster *clusterv1.ManagedCluster
 	return f
 }
 
+// WithAgentDeployTriggerClusterFilter defines the filter func to trigger the agent deploy/redploy when cluster info is
+// changed. Addons that need information from the ManagedCluster resource when deploying the agent should use this
+// function to set what information they need, otherwise the expected/up-to-date agent may be deployed delayed since the
+// default filter func returns false when the ManagedCluster resource is updated.
+//
+// For example, the agentAddon needs information from the ManagedCluster annotation, it can set the filter function
+// like:
+//
+//	WithAgentDeployClusterTriggerFilter(func(old, new *clusterv1.ManagedCluster) bool {
+//	 return !equality.Semantic.DeepEqual(old.Annotations, new.Annotations)
+//	})
+func (f *AgentAddonFactory) WithAgentDeployTriggerClusterFilter(
+	filter func(old, new *clusterv1.ManagedCluster) bool,
+) *AgentAddonFactory {
+	f.agentAddonOptions.AgentDeployTriggerClusterFilter = filter
+	return f
+}
+
 // BuildHelmAgentAddon builds a helm agentAddon instance.
 func (f *AgentAddonFactory) BuildHelmAgentAddon() (agent.AgentAddon, error) {
 	if err := validateSupportedConfigGVRs(f.agentAddonOptions.SupportedConfigGVRs); err != nil {

--- a/pkg/addonmanager/manager.go
+++ b/pkg/addonmanager/manager.go
@@ -158,31 +158,21 @@ func (a *addonManager) Start(ctx context.Context) error {
 		return err
 	}
 
-	// addonConfigController
 	err = addonInformers.Addon().V1alpha1().ManagedClusterAddOns().Informer().AddIndexers(
-		cache.Indexers{index.AddonByConfig: index.IndexAddonByConfig},
+		cache.Indexers{
+			index.ManagedClusterAddonByNamespace: index.IndexManagedClusterAddonByNamespace, // addonDeployController
+			index.ManagedClusterAddonByName:      index.IndexManagedClusterAddonByName,      // addonConfigController
+			index.AddonByConfig:                  index.IndexAddonByConfig,                  // addonConfigController
+		},
 	)
 	if err != nil {
 		return err
 	}
 
-	// managementAddonConfigController
-	err = addonInformers.Addon().V1alpha1().ClusterManagementAddOns().Informer().AddIndexers(
-		cache.Indexers{index.ClusterManagementAddonByConfig: index.IndexClusterManagementAddonByConfig})
-	if err != nil {
-		return err
-	}
-
 	err = addonInformers.Addon().V1alpha1().ClusterManagementAddOns().Informer().AddIndexers(
 		cache.Indexers{
-			index.ClusterManagementAddonByPlacement: index.IndexClusterManagementAddonByPlacement,
-		})
-	if err != nil {
-		return err
-	}
-	err = addonInformers.Addon().V1alpha1().ManagedClusterAddOns().Informer().AddIndexers(
-		cache.Indexers{
-			index.ManagedClusterAddonByName: index.IndexManagedClusterAddonByName,
+			index.ClusterManagementAddonByConfig:    index.IndexClusterManagementAddonByConfig,    // managementAddonConfigController
+			index.ClusterManagementAddonByPlacement: index.IndexClusterManagementAddonByPlacement, // addonConfigController
 		})
 	if err != nil {
 		return err

--- a/pkg/agent/inteface.go
+++ b/pkg/agent/inteface.go
@@ -76,6 +76,19 @@ type AgentAddonOptions struct {
 	// SupportedConfigGVRs is a list of addon supported configuration GroupVersionResource
 	// each configuration GroupVersionResource should be unique
 	SupportedConfigGVRs []schema.GroupVersionResource
+
+	// AgentDeployTriggerClusterFilter defines the filter func to trigger the agent deploy/redploy when cluster info is
+	// changed. Addons that need information from the ManagedCluster resource when deploying the agent should use this
+	// field to set what information they need, otherwise the expected/up-to-date agent may be deployed delayed since
+	// the default filter func returns false when the ManagedCluster resource is updated.
+	//
+	// For example, the agentAddon needs information from the ManagedCluster annotation, it can set the filter function
+	// like:
+	//
+	//	AgentDeployTriggerClusterFilter: func(old, new *clusterv1.ManagedCluster) bool {
+	//	 return !equality.Semantic.DeepEqual(old.Annotations, new.Annotations)
+	//	}
+	AgentDeployTriggerClusterFilter func(old, new *clusterv1.ManagedCluster) bool
 }
 
 type CSRSignerFunc func(csr *certificatesv1.CertificateSigningRequest) []byte

--- a/pkg/index/index.go
+++ b/pkg/index/index.go
@@ -21,6 +21,7 @@ import (
 const (
 	ClusterManagementAddonByPlacement = "clusterManagementAddonByPlacement"
 	ManagedClusterAddonByName         = "managedClusterAddonByName"
+	ManagedClusterAddonByNamespace    = "managedClusterAddonByNamespace"
 )
 
 func IndexClusterManagementAddonByPlacement(obj interface{}) ([]string, error) {
@@ -51,6 +52,16 @@ func IndexManagedClusterAddonByName(obj interface{}) ([]string, error) {
 	}
 
 	return []string{mca.Name}, nil
+}
+
+func IndexManagedClusterAddonByNamespace(obj interface{}) ([]string, error) {
+	mca, ok := obj.(*addonv1alpha1.ManagedClusterAddOn)
+
+	if !ok {
+		return []string{}, fmt.Errorf("obj %T is not a ManagedClusterAddon", obj)
+	}
+
+	return []string{mca.Namespace}, nil
 }
 
 func ClusterManagementAddonByPlacementQueueKey(

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -103,6 +103,15 @@ var _ = ginkgo.BeforeSuite(func() {
 				return err
 			}
 
+			// make the e2e test idempotent to ease debugging in local environment
+			for _, condition := range csr.Status.Conditions {
+				if condition.Type == certificatesv1.CertificateApproved {
+					if condition.Status == corev1.ConditionTrue {
+						return nil
+					}
+				}
+			}
+
 			csr.Status.Conditions = append(csr.Status.Conditions, certificatesv1.CertificateSigningRequestCondition{
 				Type:    certificatesv1.CertificateApproved,
 				Status:  corev1.ConditionTrue,

--- a/test/e2e/helloworld_helm_test.go
+++ b/test/e2e/helloworld_helm_test.go
@@ -457,30 +457,6 @@ var _ = ginkgo.Describe("install/uninstall helloworld helm addons", func() {
 			return err
 		}, eventuallyTimeout, eventuallyInterval).ShouldNot(gomega.HaveOccurred())
 
-		// TODO: make the addon-framework deploy controller watch the ManagedCluster resurce, after that
-		// we can remove this
-		ginkgo.By("UPDATE ManagedClusterAddOn to trigger reconcile")
-		gomega.Eventually(func() error {
-			addon, err := hubAddOnClient.AddonV1alpha1().ManagedClusterAddOns(managedClusterName).Get(
-				context.Background(), helloWorldHelmAddonName, metav1.GetOptions{})
-			if err != nil {
-				return err
-			}
-			newAddon := addon.DeepCopy()
-			annotations := addon.Annotations
-			if annotations == nil {
-				annotations = make(map[string]string)
-			}
-			annotations["test"] = rand.String(6)
-			newAddon.Annotations = annotations
-			_, err = hubAddOnClient.AddonV1alpha1().ManagedClusterAddOns(managedClusterName).Update(
-				context.Background(), newAddon, metav1.UpdateOptions{})
-			if err != nil {
-				return err
-			}
-			return nil
-		}, eventuallyTimeout, eventuallyInterval).ShouldNot(gomega.HaveOccurred())
-
 		ginkgo.By("Make sure addon is configured")
 		gomega.Eventually(func() error {
 			agentDeploy, err := hubKubeClient.AppsV1().Deployments(addonInstallNamespace).Get(


### PR DESCRIPTION
Provide an option for developer to make the agent deploy controller watches the managed cluster, so if there are any changes on the managed cluster, the agent deploy controller can reconcile quickly

for example: if a helm addon wants managed cluster annotation changing trigger the agent redeploy:
```
.WithAgentDeployTriggerClusterFilter(func(old, new *clusterv1.ManagedCluster) bool {
			return !equality.Semantic.DeepEqual(old.Annotations, new.Annotations)
		})
```

issue reference: https://github.com/open-cluster-management-io/addon-framework/issues/198