### PR TITLE
:bug: Skip health check for deployments whose replicas is 0

### DIFF
--- a/pkg/addonmanager/controllers/agentdeploy/healthcheck_sync.go
+++ b/pkg/addonmanager/controllers/agentdeploy/healthcheck_sync.go
@@ -221,6 +221,10 @@ func (s *healthCheckSyncer) analyzeDeploymentWorkProber(
 	deployments := utils.FilterDeployments(manifests)
 	for _, deployment := range deployments {
 		manifestConfig := utils.DeploymentWellKnowManifestConfig(deployment.Namespace, deployment.Name)
+		// only probe the deployment with non-zero replicas
+		if deployment.Spec.Replicas != nil && *deployment.Spec.Replicas == 0 {
+			continue
+		}
 		probeFields = append(probeFields, agent.ProbeField{
 			ResourceIdentifier: manifestConfig.ResourceIdentifier,
 			ProbeRules:         manifestConfig.FeedbackRules,

--- a/pkg/utils/probe_helper.go
+++ b/pkg/utils/probe_helper.go
@@ -64,30 +64,22 @@ func DeploymentAvailabilityHealthCheck(identifier workapiv1.ResourceIdentifier, 
 		return fmt.Errorf("unsupported resource group %s", identifier.Group)
 	}
 
-	var readyReplicas, replicas int64 = -1, -1
+	if len(result.Values) == 0 {
+		return fmt.Errorf("no values are probed for deployment %s/%s", identifier.Namespace, identifier.Name)
+	}
 	for _, value := range result.Values {
-		if value.Name == "Replicas" {
-			replicas = *value.Value.Integer
+		if value.Name != "ReadyReplicas" {
+			continue
 		}
-		if value.Name == "ReadyReplicas" {
-			readyReplicas = *value.Value.Integer
+
+		if *value.Value.Integer >= 1 {
+			return nil
 		}
-	}
 
-	if readyReplicas == -1 || replicas == -1 {
-		return fmt.Errorf("readyReplicas or replicas is not probed for deployment %s/%s",
-			identifier.Namespace, identifier.Name)
+		return fmt.Errorf("readyReplica is %d for deployment %s/%s",
+			*value.Value.Integer, identifier.Namespace, identifier.Name)
 	}
-
-	if replicas == 0 {
-		return nil
-	}
-
-	if readyReplicas >= 1 {
-		return nil
-	}
-
-	return fmt.Errorf("readyReplica is %d for deployment %s/%s", readyReplicas, identifier.Namespace, identifier.Name)
+	return fmt.Errorf("readyReplica is not probed")
 }
 
 func FilterDeployments(objects []runtime.Object) []*appsv1.Deployment {

--- a/pkg/utils/probe_helper_test.go
+++ b/pkg/utils/probe_helper_test.go
@@ -24,7 +24,7 @@ func TestDeploymentProbe(t *testing.T) {
 		{
 			name:        "no result",
 			result:      workapiv1.StatusFeedbackResult{},
-			expectedErr: "readyReplicas or replicas is not probed for deployment testns/test",
+			expectedErr: "no values are probed for deployment testns/test",
 		},
 		{
 			name: "no matched value",
@@ -44,7 +44,7 @@ func TestDeploymentProbe(t *testing.T) {
 					},
 				},
 			},
-			expectedErr: "readyReplicas or replicas is not probed for deployment testns/test",
+			expectedErr: "readyReplica is not probed",
 		},
 		{
 			name: "check failed with 0 ready replica",
@@ -80,26 +80,6 @@ func TestDeploymentProbe(t *testing.T) {
 						Name: "ReadyReplicas",
 						Value: workapiv1.FieldValue{
 							Integer: boolPtr(2),
-						},
-					},
-				},
-			},
-			expectedErr: "",
-		},
-		{
-			name: "check passed when replica is 0",
-			result: workapiv1.StatusFeedbackResult{
-				Values: []workapiv1.FeedbackValue{
-					{
-						Name: "Replicas",
-						Value: workapiv1.FieldValue{
-							Integer: boolPtr(0),
-						},
-					},
-					{
-						Name: "ReadyReplicas",
-						Value: workapiv1.FieldValue{
-							Integer: boolPtr(0),
 						},
 					},
 				},


### PR DESCRIPTION
In some cases, we want to deploy a deployment resource whose replicas is 0 to the managed cluster, if we set the health probe type to "DeploymentAvailability", the addon can not become available since the readyReplicas is 0. In this situation, we want to make the health probe check pass for the addon.