### PR TITLE
print warning message when mca's ownerref is not set

### DIFF
--- a/pkg/addonmanager/controllers/registration/controller.go
+++ b/pkg/addonmanager/controllers/registration/controller.go
@@ -99,6 +99,7 @@ func (c *addonRegistrationController) sync(ctx context.Context, syncCtx factory.
 
 	// wait until the mca's ownerref is set.
 	if !utils.IsOwnedByCMA(managedClusterAddonCopy) {
+		klog.Warningf("OwnerReferences is not set for %q", key)
 		return nil
 	}
 


### PR DESCRIPTION
When cma is not created, mca's ownerref will be empty and return nil without any log, add a warning log for easy debugging.