### PR TITLE
Sort manifests by Kind and set namespace like helm

### DIFF
--- a/pkg/addonfactory/addonfactory.go
+++ b/pkg/addonfactory/addonfactory.go
@@ -34,9 +34,11 @@ type AgentAddonFactory struct {
 	getValuesFuncs    []GetValuesFunc
 	agentAddonOptions agent.AgentAddonOptions
 	// trimCRDDescription flag is used to trim the description of CRDs in manifestWork. disabled by default.
-	trimCRDDescription    bool
-	hostingCluster        *clusterv1.ManagedCluster
-	agentInstallNamespace func(addon *addonapiv1alpha1.ManagedClusterAddOn) string
+	trimCRDDescription          bool
+	hostingCluster              *clusterv1.ManagedCluster
+	agentInstallNamespace       func(addon *addonapiv1alpha1.ManagedClusterAddOn) string
+	createAgentInstallNamespace bool
+	helmEngineStrict            bool
 }
 
 // NewAgentAddonFactory builds an addonAgentFactory instance with addon name and fs.
@@ -57,8 +59,10 @@ func NewAgentAddonFactory(addonName string, fs embed.FS, dir string) *AgentAddon
 			HealthProber:        nil,
 			SupportedConfigGVRs: []schema.GroupVersionResource{},
 		},
-		trimCRDDescription: false,
-		scheme:             s,
+		trimCRDDescription:          false,
+		scheme:                      s,
+		createAgentInstallNamespace: false,
+		helmEngineStrict:            false,
 	}
 }
 
@@ -112,6 +116,18 @@ func (f *AgentAddonFactory) WithAgentHostedModeEnabledOption() *AgentAddonFactor
 // WithTrimCRDDescription is to enable trim the description of CRDs in manifestWork.
 func (f *AgentAddonFactory) WithTrimCRDDescription() *AgentAddonFactory {
 	f.trimCRDDescription = true
+	return f
+}
+
+// WithCreateAgentInstallNamespace is to create the agent install namespace object in manifestWork.
+func (f *AgentAddonFactory) WithCreateAgentInstallNamespace() *AgentAddonFactory {
+	f.createAgentInstallNamespace = true
+	return f
+}
+
+// WithHelmEngineStrict is to enable script go template rendering for Helm charts to generate manifestWork.
+func (f *AgentAddonFactory) WithHelmEngineStrict() *AgentAddonFactory {
+	f.helmEngineStrict = true
 	return f
 }
 

--- a/vendor/helm.sh/helm/v3/pkg/release/hook.go
+++ b/vendor/helm.sh/helm/v3/pkg/release/hook.go
@@ -1,0 +1,106 @@
+/*
+Copyright The Helm Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package release
+
+import (
+	"helm.sh/helm/v3/pkg/time"
+)
+
+// HookEvent specifies the hook event
+type HookEvent string
+
+// Hook event types
+const (
+	HookPreInstall   HookEvent = "pre-install"
+	HookPostInstall  HookEvent = "post-install"
+	HookPreDelete    HookEvent = "pre-delete"
+	HookPostDelete   HookEvent = "post-delete"
+	HookPreUpgrade   HookEvent = "pre-upgrade"
+	HookPostUpgrade  HookEvent = "post-upgrade"
+	HookPreRollback  HookEvent = "pre-rollback"
+	HookPostRollback HookEvent = "post-rollback"
+	HookTest         HookEvent = "test"
+)
+
+func (x HookEvent) String() string { return string(x) }
+
+// HookDeletePolicy specifies the hook delete policy
+type HookDeletePolicy string
+
+// Hook delete policy types
+const (
+	HookSucceeded          HookDeletePolicy = "hook-succeeded"
+	HookFailed             HookDeletePolicy = "hook-failed"
+	HookBeforeHookCreation HookDeletePolicy = "before-hook-creation"
+)
+
+func (x HookDeletePolicy) String() string { return string(x) }
+
+// HookAnnotation is the label name for a hook
+const HookAnnotation = "helm.sh/hook"
+
+// HookWeightAnnotation is the label name for a hook weight
+const HookWeightAnnotation = "helm.sh/hook-weight"
+
+// HookDeleteAnnotation is the label name for the delete policy for a hook
+const HookDeleteAnnotation = "helm.sh/hook-delete-policy"
+
+// Hook defines a hook object.
+type Hook struct {
+	Name string `json:"name,omitempty"`
+	// Kind is the Kubernetes kind.
+	Kind string `json:"kind,omitempty"`
+	// Path is the chart-relative path to the template.
+	Path string `json:"path,omitempty"`
+	// Manifest is the manifest contents.
+	Manifest string `json:"manifest,omitempty"`
+	// Events are the events that this hook fires on.
+	Events []HookEvent `json:"events,omitempty"`
+	// LastRun indicates the date/time this was last run.
+	LastRun HookExecution `json:"last_run,omitempty"`
+	// Weight indicates the sort order for execution among similar Hook type
+	Weight int `json:"weight,omitempty"`
+	// DeletePolicies are the policies that indicate when to delete the hook
+	DeletePolicies []HookDeletePolicy `json:"delete_policies,omitempty"`
+}
+
+// A HookExecution records the result for the last execution of a hook for a given release.
+type HookExecution struct {
+	// StartedAt indicates the date/time this hook was started
+	StartedAt time.Time `json:"started_at,omitempty"`
+	// CompletedAt indicates the date/time this hook was completed.
+	CompletedAt time.Time `json:"completed_at,omitempty"`
+	// Phase indicates whether the hook completed successfully
+	Phase HookPhase `json:"phase"`
+}
+
+// A HookPhase indicates the state of a hook execution
+type HookPhase string
+
+const (
+	// HookPhaseUnknown indicates that a hook is in an unknown state
+	HookPhaseUnknown HookPhase = "Unknown"
+	// HookPhaseRunning indicates that a hook is currently executing
+	HookPhaseRunning HookPhase = "Running"
+	// HookPhaseSucceeded indicates that hook execution succeeded
+	HookPhaseSucceeded HookPhase = "Succeeded"
+	// HookPhaseFailed indicates that hook execution failed
+	HookPhaseFailed HookPhase = "Failed"
+)
+
+// String converts a hook phase to a printable string
+func (x HookPhase) String() string { return string(x) }

--- a/vendor/helm.sh/helm/v3/pkg/release/info.go
+++ b/vendor/helm.sh/helm/v3/pkg/release/info.go
@@ -1,0 +1,40 @@
+/*
+Copyright The Helm Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package release
+
+import (
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"helm.sh/helm/v3/pkg/time"
+)
+
+// Info describes release information.
+type Info struct {
+	// FirstDeployed is when the release was first deployed.
+	FirstDeployed time.Time `json:"first_deployed,omitempty"`
+	// LastDeployed is when the release was last deployed.
+	LastDeployed time.Time `json:"last_deployed,omitempty"`
+	// Deleted tracks when this object was deleted.
+	Deleted time.Time `json:"deleted"`
+	// Description is human-friendly "log entry" about this release.
+	Description string `json:"description,omitempty"`
+	// Status is the current state of the release
+	Status Status `json:"status,omitempty"`
+	// Contains the rendered templates/NOTES.txt if available
+	Notes string `json:"notes,omitempty"`
+	// Contains the deployed resources information
+	Resources map[string][]runtime.Object `json:"resources,omitempty"`
+}

--- a/vendor/helm.sh/helm/v3/pkg/release/mock.go
+++ b/vendor/helm.sh/helm/v3/pkg/release/mock.go
@@ -1,0 +1,116 @@
+/*
+Copyright The Helm Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package release
+
+import (
+	"fmt"
+	"math/rand"
+
+	"helm.sh/helm/v3/pkg/chart"
+	"helm.sh/helm/v3/pkg/time"
+)
+
+// MockHookTemplate is the hook template used for all mock release objects.
+var MockHookTemplate = `apiVersion: v1
+kind: Job
+metadata:
+  annotations:
+    "helm.sh/hook": pre-install
+`
+
+// MockManifest is the manifest used for all mock release objects.
+var MockManifest = `apiVersion: v1
+kind: Secret
+metadata:
+  name: fixture
+`
+
+// MockReleaseOptions allows for user-configurable options on mock release objects.
+type MockReleaseOptions struct {
+	Name      string
+	Version   int
+	Chart     *chart.Chart
+	Status    Status
+	Namespace string
+}
+
+// Mock creates a mock release object based on options set by MockReleaseOptions. This function should typically not be used outside of testing.
+func Mock(opts *MockReleaseOptions) *Release {
+	date := time.Unix(242085845, 0).UTC()
+
+	name := opts.Name
+	if name == "" {
+		name = "testrelease-" + fmt.Sprint(rand.Intn(100))
+	}
+
+	version := 1
+	if opts.Version != 0 {
+		version = opts.Version
+	}
+
+	namespace := opts.Namespace
+	if namespace == "" {
+		namespace = "default"
+	}
+
+	ch := opts.Chart
+	if opts.Chart == nil {
+		ch = &chart.Chart{
+			Metadata: &chart.Metadata{
+				Name:       "foo",
+				Version:    "0.1.0-beta.1",
+				AppVersion: "1.0",
+			},
+			Templates: []*chart.File{
+				{Name: "templates/foo.tpl", Data: []byte(MockManifest)},
+			},
+		}
+	}
+
+	scode := StatusDeployed
+	if len(opts.Status) > 0 {
+		scode = opts.Status
+	}
+
+	info := &Info{
+		FirstDeployed: date,
+		LastDeployed:  date,
+		Status:        scode,
+		Description:   "Release mock",
+		Notes:         "Some mock release notes!",
+	}
+
+	return &Release{
+		Name:      name,
+		Info:      info,
+		Chart:     ch,
+		Config:    map[string]interface{}{"name": "value"},
+		Version:   version,
+		Namespace: namespace,
+		Hooks: []*Hook{
+			{
+				Name:     "pre-install-hook",
+				Kind:     "Job",
+				Path:     "pre-install-hook.yaml",
+				Manifest: MockHookTemplate,
+				LastRun:  HookExecution{},
+				Events:   []HookEvent{HookPreInstall},
+			},
+		},
+		Manifest: MockManifest,
+	}
+}

--- a/vendor/helm.sh/helm/v3/pkg/release/release.go
+++ b/vendor/helm.sh/helm/v3/pkg/release/release.go
@@ -1,0 +1,49 @@
+/*
+Copyright The Helm Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package release
+
+import "helm.sh/helm/v3/pkg/chart"
+
+// Release describes a deployment of a chart, together with the chart
+// and the variables used to deploy that chart.
+type Release struct {
+	// Name is the name of the release
+	Name string `json:"name,omitempty"`
+	// Info provides information about a release
+	Info *Info `json:"info,omitempty"`
+	// Chart is the chart that was released.
+	Chart *chart.Chart `json:"chart,omitempty"`
+	// Config is the set of extra Values added to the chart.
+	// These values override the default values inside of the chart.
+	Config map[string]interface{} `json:"config,omitempty"`
+	// Manifest is the string representation of the rendered template.
+	Manifest string `json:"manifest,omitempty"`
+	// Hooks are all of the hooks declared for this release.
+	Hooks []*Hook `json:"hooks,omitempty"`
+	// Version is an int which represents the revision of the release.
+	Version int `json:"version,omitempty"`
+	// Namespace is the kubernetes namespace of the release.
+	Namespace string `json:"namespace,omitempty"`
+	// Labels of the release.
+	// Disabled encoding into Json cause labels are stored in storage driver metadata field.
+	Labels map[string]string `json:"-"`
+}
+
+// SetStatus is a helper for setting the status on a release.
+func (r *Release) SetStatus(status Status, msg string) {
+	r.Info.Status = status
+	r.Info.Description = msg
+}

--- a/vendor/helm.sh/helm/v3/pkg/release/responses.go
+++ b/vendor/helm.sh/helm/v3/pkg/release/responses.go
@@ -1,0 +1,24 @@
+/*
+Copyright The Helm Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package release
+
+// UninstallReleaseResponse represents a successful response to an uninstall request.
+type UninstallReleaseResponse struct {
+	// Release is the release that was marked deleted.
+	Release *Release `json:"release,omitempty"`
+	// Info is an uninstall message
+	Info string `json:"info,omitempty"`
+}

--- a/vendor/helm.sh/helm/v3/pkg/release/status.go
+++ b/vendor/helm.sh/helm/v3/pkg/release/status.go
@@ -1,0 +1,49 @@
+/*
+Copyright The Helm Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package release
+
+// Status is the status of a release
+type Status string
+
+// Describe the status of a release
+// NOTE: Make sure to update cmd/helm/status.go when adding or modifying any of these statuses.
+const (
+	// StatusUnknown indicates that a release is in an uncertain state.
+	StatusUnknown Status = "unknown"
+	// StatusDeployed indicates that the release has been pushed to Kubernetes.
+	StatusDeployed Status = "deployed"
+	// StatusUninstalled indicates that a release has been uninstalled from Kubernetes.
+	StatusUninstalled Status = "uninstalled"
+	// StatusSuperseded indicates that this release object is outdated and a newer one exists.
+	StatusSuperseded Status = "superseded"
+	// StatusFailed indicates that the release was not successfully deployed.
+	StatusFailed Status = "failed"
+	// StatusUninstalling indicates that a uninstall operation is underway.
+	StatusUninstalling Status = "uninstalling"
+	// StatusPendingInstall indicates that an install operation is underway.
+	StatusPendingInstall Status = "pending-install"
+	// StatusPendingUpgrade indicates that an upgrade operation is underway.
+	StatusPendingUpgrade Status = "pending-upgrade"
+	// StatusPendingRollback indicates that an rollback operation is underway.
+	StatusPendingRollback Status = "pending-rollback"
+)
+
+func (x Status) String() string { return string(x) }
+
+// IsPending determines if this status is a state or a transition.
+func (x Status) IsPending() bool {
+	return x == StatusPendingInstall || x == StatusPendingUpgrade || x == StatusPendingRollback
+}

--- a/vendor/helm.sh/helm/v3/pkg/releaseutil/filter.go
+++ b/vendor/helm.sh/helm/v3/pkg/releaseutil/filter.go
@@ -1,0 +1,78 @@
+/*
+Copyright The Helm Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package releaseutil // import "helm.sh/helm/v3/pkg/releaseutil"
+
+import rspb "helm.sh/helm/v3/pkg/release"
+
+// FilterFunc returns true if the release object satisfies
+// the predicate of the underlying filter func.
+type FilterFunc func(*rspb.Release) bool
+
+// Check applies the FilterFunc to the release object.
+func (fn FilterFunc) Check(rls *rspb.Release) bool {
+	if rls == nil {
+		return false
+	}
+	return fn(rls)
+}
+
+// Filter applies the filter(s) to the list of provided releases
+// returning the list that satisfies the filtering predicate.
+func (fn FilterFunc) Filter(rels []*rspb.Release) (rets []*rspb.Release) {
+	for _, rel := range rels {
+		if fn.Check(rel) {
+			rets = append(rets, rel)
+		}
+	}
+	return
+}
+
+// Any returns a FilterFunc that filters a list of releases
+// determined by the predicate 'f0 || f1 || ... || fn'.
+func Any(filters ...FilterFunc) FilterFunc {
+	return func(rls *rspb.Release) bool {
+		for _, filter := range filters {
+			if filter(rls) {
+				return true
+			}
+		}
+		return false
+	}
+}
+
+// All returns a FilterFunc that filters a list of releases
+// determined by the predicate 'f0 && f1 && ... && fn'.
+func All(filters ...FilterFunc) FilterFunc {
+	return func(rls *rspb.Release) bool {
+		for _, filter := range filters {
+			if !filter(rls) {
+				return false
+			}
+		}
+		return true
+	}
+}
+
+// StatusFilter filters a set of releases by status code.
+func StatusFilter(status rspb.Status) FilterFunc {
+	return FilterFunc(func(rls *rspb.Release) bool {
+		if rls == nil {
+			return true
+		}
+		return rls.Info.Status == status
+	})
+}

--- a/vendor/helm.sh/helm/v3/pkg/releaseutil/kind_sorter.go
+++ b/vendor/helm.sh/helm/v3/pkg/releaseutil/kind_sorter.go
@@ -1,0 +1,160 @@
+/*
+Copyright The Helm Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package releaseutil
+
+import (
+	"sort"
+
+	"helm.sh/helm/v3/pkg/release"
+)
+
+// KindSortOrder is an ordering of Kinds.
+type KindSortOrder []string
+
+// InstallOrder is the order in which manifests should be installed (by Kind).
+//
+// Those occurring earlier in the list get installed before those occurring later in the list.
+var InstallOrder KindSortOrder = []string{
+	"PriorityClass",
+	"Namespace",
+	"NetworkPolicy",
+	"ResourceQuota",
+	"LimitRange",
+	"PodSecurityPolicy",
+	"PodDisruptionBudget",
+	"ServiceAccount",
+	"Secret",
+	"SecretList",
+	"ConfigMap",
+	"StorageClass",
+	"PersistentVolume",
+	"PersistentVolumeClaim",
+	"CustomResourceDefinition",
+	"ClusterRole",
+	"ClusterRoleList",
+	"ClusterRoleBinding",
+	"ClusterRoleBindingList",
+	"Role",
+	"RoleList",
+	"RoleBinding",
+	"RoleBindingList",
+	"Service",
+	"DaemonSet",
+	"Pod",
+	"ReplicationController",
+	"ReplicaSet",
+	"Deployment",
+	"HorizontalPodAutoscaler",
+	"StatefulSet",
+	"Job",
+	"CronJob",
+	"IngressClass",
+	"Ingress",
+	"APIService",
+}
+
+// UninstallOrder is the order in which manifests should be uninstalled (by Kind).
+//
+// Those occurring earlier in the list get uninstalled before those occurring later in the list.
+var UninstallOrder KindSortOrder = []string{
+	"APIService",
+	"Ingress",
+	"IngressClass",
+	"Service",
+	"CronJob",
+	"Job",
+	"StatefulSet",
+	"HorizontalPodAutoscaler",
+	"Deployment",
+	"ReplicaSet",
+	"ReplicationController",
+	"Pod",
+	"DaemonSet",
+	"RoleBindingList",
+	"RoleBinding",
+	"RoleList",
+	"Role",
+	"ClusterRoleBindingList",
+	"ClusterRoleBinding",
+	"ClusterRoleList",
+	"ClusterRole",
+	"CustomResourceDefinition",
+	"PersistentVolumeClaim",
+	"PersistentVolume",
+	"StorageClass",
+	"ConfigMap",
+	"SecretList",
+	"Secret",
+	"ServiceAccount",
+	"PodDisruptionBudget",
+	"PodSecurityPolicy",
+	"LimitRange",
+	"ResourceQuota",
+	"NetworkPolicy",
+	"Namespace",
+	"PriorityClass",
+}
+
+// sort manifests by kind.
+//
+// Results are sorted by 'ordering', keeping order of items with equal kind/priority
+func sortManifestsByKind(manifests []Manifest, ordering KindSortOrder) []Manifest {
+	sort.SliceStable(manifests, func(i, j int) bool {
+		return lessByKind(manifests[i], manifests[j], manifests[i].Head.Kind, manifests[j].Head.Kind, ordering)
+	})
+
+	return manifests
+}
+
+// sort hooks by kind, using an out-of-place sort to preserve the input parameters.
+//
+// Results are sorted by 'ordering', keeping order of items with equal kind/priority
+func sortHooksByKind(hooks []*release.Hook, ordering KindSortOrder) []*release.Hook {
+	h := hooks
+	sort.SliceStable(h, func(i, j int) bool {
+		return lessByKind(h[i], h[j], h[i].Kind, h[j].Kind, ordering)
+	})
+
+	return h
+}
+
+func lessByKind(_ interface{}, _ interface{}, kindA string, kindB string, o KindSortOrder) bool {
+	ordering := make(map[string]int, len(o))
+	for v, k := range o {
+		ordering[k] = v
+	}
+
+	first, aok := ordering[kindA]
+	second, bok := ordering[kindB]
+
+	if !aok && !bok {
+		// if both are unknown then sort alphabetically by kind, keep original order if same kind
+		if kindA != kindB {
+			return kindA < kindB
+		}
+		return first < second
+	}
+	// unknown kind is last
+	if !aok {
+		return false
+	}
+	if !bok {
+		return true
+	}
+	// sort different kinds, keep original order if same priority
+	return first < second
+}

--- a/vendor/helm.sh/helm/v3/pkg/releaseutil/manifest.go
+++ b/vendor/helm.sh/helm/v3/pkg/releaseutil/manifest.go
@@ -1,0 +1,72 @@
+/*
+Copyright The Helm Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package releaseutil
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// SimpleHead defines what the structure of the head of a manifest file
+type SimpleHead struct {
+	Version  string `json:"apiVersion"`
+	Kind     string `json:"kind,omitempty"`
+	Metadata *struct {
+		Name        string            `json:"name"`
+		Annotations map[string]string `json:"annotations"`
+	} `json:"metadata,omitempty"`
+}
+
+var sep = regexp.MustCompile("(?:^|\\s*\n)---\\s*")
+
+// SplitManifests takes a string of manifest and returns a map contains individual manifests
+func SplitManifests(bigFile string) map[string]string {
+	// Basically, we're quickly splitting a stream of YAML documents into an
+	// array of YAML docs. The file name is just a place holder, but should be
+	// integer-sortable so that manifests get output in the same order as the
+	// input (see `BySplitManifestsOrder`).
+	tpl := "manifest-%d"
+	res := map[string]string{}
+	// Making sure that any extra whitespace in YAML stream doesn't interfere in splitting documents correctly.
+	bigFileTmp := strings.TrimSpace(bigFile)
+	docs := sep.Split(bigFileTmp, -1)
+	var count int
+	for _, d := range docs {
+		if d == "" {
+			continue
+		}
+
+		d = strings.TrimSpace(d)
+		res[fmt.Sprintf(tpl, count)] = d
+		count = count + 1
+	}
+	return res
+}
+
+// BySplitManifestsOrder sorts by in-file manifest order, as provided in function `SplitManifests`
+type BySplitManifestsOrder []string
+
+func (a BySplitManifestsOrder) Len() int { return len(a) }
+func (a BySplitManifestsOrder) Less(i, j int) bool {
+	// Split `manifest-%d`
+	anum, _ := strconv.ParseInt(a[i][len("manifest-"):], 10, 0)
+	bnum, _ := strconv.ParseInt(a[j][len("manifest-"):], 10, 0)
+	return anum < bnum
+}
+func (a BySplitManifestsOrder) Swap(i, j int) { a[i], a[j] = a[j], a[i] }

--- a/vendor/helm.sh/helm/v3/pkg/releaseutil/manifest_sorter.go
+++ b/vendor/helm.sh/helm/v3/pkg/releaseutil/manifest_sorter.go
@@ -1,0 +1,233 @@
+/*
+Copyright The Helm Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package releaseutil
+
+import (
+	"log"
+	"path"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/pkg/errors"
+	"sigs.k8s.io/yaml"
+
+	"helm.sh/helm/v3/pkg/chartutil"
+	"helm.sh/helm/v3/pkg/release"
+)
+
+// Manifest represents a manifest file, which has a name and some content.
+type Manifest struct {
+	Name    string
+	Content string
+	Head    *SimpleHead
+}
+
+// manifestFile represents a file that contains a manifest.
+type manifestFile struct {
+	entries map[string]string
+	path    string
+	apis    chartutil.VersionSet
+}
+
+// result is an intermediate structure used during sorting.
+type result struct {
+	hooks   []*release.Hook
+	generic []Manifest
+}
+
+// TODO: Refactor this out. It's here because naming conventions were not followed through.
+// So fix the Test hook names and then remove this.
+var events = map[string]release.HookEvent{
+	release.HookPreInstall.String():   release.HookPreInstall,
+	release.HookPostInstall.String():  release.HookPostInstall,
+	release.HookPreDelete.String():    release.HookPreDelete,
+	release.HookPostDelete.String():   release.HookPostDelete,
+	release.HookPreUpgrade.String():   release.HookPreUpgrade,
+	release.HookPostUpgrade.String():  release.HookPostUpgrade,
+	release.HookPreRollback.String():  release.HookPreRollback,
+	release.HookPostRollback.String(): release.HookPostRollback,
+	release.HookTest.String():         release.HookTest,
+	// Support test-success for backward compatibility with Helm 2 tests
+	"test-success": release.HookTest,
+}
+
+// SortManifests takes a map of filename/YAML contents, splits the file
+// by manifest entries, and sorts the entries into hook types.
+//
+// The resulting hooks struct will be populated with all of the generated hooks.
+// Any file that does not declare one of the hook types will be placed in the
+// 'generic' bucket.
+//
+// Files that do not parse into the expected format are simply placed into a map and
+// returned.
+func SortManifests(files map[string]string, apis chartutil.VersionSet, ordering KindSortOrder) ([]*release.Hook, []Manifest, error) {
+	result := &result{}
+
+	var sortedFilePaths []string
+	for filePath := range files {
+		sortedFilePaths = append(sortedFilePaths, filePath)
+	}
+	sort.Strings(sortedFilePaths)
+
+	for _, filePath := range sortedFilePaths {
+		content := files[filePath]
+
+		// Skip partials. We could return these as a separate map, but there doesn't
+		// seem to be any need for that at this time.
+		if strings.HasPrefix(path.Base(filePath), "_") {
+			continue
+		}
+		// Skip empty files and log this.
+		if strings.TrimSpace(content) == "" {
+			continue
+		}
+
+		manifestFile := &manifestFile{
+			entries: SplitManifests(content),
+			path:    filePath,
+			apis:    apis,
+		}
+
+		if err := manifestFile.sort(result); err != nil {
+			return result.hooks, result.generic, err
+		}
+	}
+
+	return sortHooksByKind(result.hooks, ordering), sortManifestsByKind(result.generic, ordering), nil
+}
+
+// sort takes a manifestFile object which may contain multiple resource definition
+// entries and sorts each entry by hook types, and saves the resulting hooks and
+// generic manifests (or non-hooks) to the result struct.
+//
+// To determine hook type, it looks for a YAML structure like this:
+//
+//	 kind: SomeKind
+//	 apiVersion: v1
+//		metadata:
+//			annotations:
+//				helm.sh/hook: pre-install
+//
+// To determine the policy to delete the hook, it looks for a YAML structure like this:
+//
+//	 kind: SomeKind
+//	 apiVersion: v1
+//	 metadata:
+//			annotations:
+//				helm.sh/hook-delete-policy: hook-succeeded
+func (file *manifestFile) sort(result *result) error {
+	// Go through manifests in order found in file (function `SplitManifests` creates integer-sortable keys)
+	var sortedEntryKeys []string
+	for entryKey := range file.entries {
+		sortedEntryKeys = append(sortedEntryKeys, entryKey)
+	}
+	sort.Sort(BySplitManifestsOrder(sortedEntryKeys))
+
+	for _, entryKey := range sortedEntryKeys {
+		m := file.entries[entryKey]
+
+		var entry SimpleHead
+		if err := yaml.Unmarshal([]byte(m), &entry); err != nil {
+			return errors.Wrapf(err, "YAML parse error on %s", file.path)
+		}
+
+		if !hasAnyAnnotation(entry) {
+			result.generic = append(result.generic, Manifest{
+				Name:    file.path,
+				Content: m,
+				Head:    &entry,
+			})
+			continue
+		}
+
+		hookTypes, ok := entry.Metadata.Annotations[release.HookAnnotation]
+		if !ok {
+			result.generic = append(result.generic, Manifest{
+				Name:    file.path,
+				Content: m,
+				Head:    &entry,
+			})
+			continue
+		}
+
+		hw := calculateHookWeight(entry)
+
+		h := &release.Hook{
+			Name:           entry.Metadata.Name,
+			Kind:           entry.Kind,
+			Path:           file.path,
+			Manifest:       m,
+			Events:         []release.HookEvent{},
+			Weight:         hw,
+			DeletePolicies: []release.HookDeletePolicy{},
+		}
+
+		isUnknownHook := false
+		for _, hookType := range strings.Split(hookTypes, ",") {
+			hookType = strings.ToLower(strings.TrimSpace(hookType))
+			e, ok := events[hookType]
+			if !ok {
+				isUnknownHook = true
+				break
+			}
+			h.Events = append(h.Events, e)
+		}
+
+		if isUnknownHook {
+			log.Printf("info: skipping unknown hook: %q", hookTypes)
+			continue
+		}
+
+		result.hooks = append(result.hooks, h)
+
+		operateAnnotationValues(entry, release.HookDeleteAnnotation, func(value string) {
+			h.DeletePolicies = append(h.DeletePolicies, release.HookDeletePolicy(value))
+		})
+	}
+
+	return nil
+}
+
+// hasAnyAnnotation returns true if the given entry has any annotations at all.
+func hasAnyAnnotation(entry SimpleHead) bool {
+	return entry.Metadata != nil &&
+		entry.Metadata.Annotations != nil &&
+		len(entry.Metadata.Annotations) != 0
+}
+
+// calculateHookWeight finds the weight in the hook weight annotation.
+//
+// If no weight is found, the assigned weight is 0
+func calculateHookWeight(entry SimpleHead) int {
+	hws := entry.Metadata.Annotations[release.HookWeightAnnotation]
+	hw, err := strconv.Atoi(hws)
+	if err != nil {
+		hw = 0
+	}
+	return hw
+}
+
+// operateAnnotationValues finds the given annotation and runs the operate function with the value of that annotation
+func operateAnnotationValues(entry SimpleHead, annotation string, operate func(p string)) {
+	if dps, ok := entry.Metadata.Annotations[annotation]; ok {
+		for _, dp := range strings.Split(dps, ",") {
+			dp = strings.ToLower(strings.TrimSpace(dp))
+			operate(dp)
+		}
+	}
+}

--- a/vendor/helm.sh/helm/v3/pkg/releaseutil/sorter.go
+++ b/vendor/helm.sh/helm/v3/pkg/releaseutil/sorter.go
@@ -1,0 +1,78 @@
+/*
+Copyright The Helm Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package releaseutil // import "helm.sh/helm/v3/pkg/releaseutil"
+
+import (
+	"sort"
+
+	rspb "helm.sh/helm/v3/pkg/release"
+)
+
+type list []*rspb.Release
+
+func (s list) Len() int      { return len(s) }
+func (s list) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
+
+// ByName sorts releases by name
+type ByName struct{ list }
+
+// Less compares to releases
+func (s ByName) Less(i, j int) bool { return s.list[i].Name < s.list[j].Name }
+
+// ByDate sorts releases by date
+type ByDate struct{ list }
+
+// Less compares to releases
+func (s ByDate) Less(i, j int) bool {
+	ti := s.list[i].Info.LastDeployed.Unix()
+	tj := s.list[j].Info.LastDeployed.Unix()
+	return ti < tj
+}
+
+// ByRevision sorts releases by revision number
+type ByRevision struct{ list }
+
+// Less compares to releases
+func (s ByRevision) Less(i, j int) bool {
+	return s.list[i].Version < s.list[j].Version
+}
+
+// Reverse reverses the list of releases sorted by the sort func.
+func Reverse(list []*rspb.Release, sortFn func([]*rspb.Release)) {
+	sortFn(list)
+	for i, j := 0, len(list)-1; i < j; i, j = i+1, j-1 {
+		list[i], list[j] = list[j], list[i]
+	}
+}
+
+// SortByName returns the list of releases sorted
+// in lexicographical order.
+func SortByName(list []*rspb.Release) {
+	sort.Sort(ByName{list})
+}
+
+// SortByDate returns the list of releases sorted by a
+// release's last deployed time (in seconds).
+func SortByDate(list []*rspb.Release) {
+	sort.Sort(ByDate{list})
+}
+
+// SortByRevision returns the list of releases sorted by a
+// release's revision number (release.Version).
+func SortByRevision(list []*rspb.Release) {
+	sort.Sort(ByRevision{list})
+}

--- a/vendor/helm.sh/helm/v3/pkg/time/time.go
+++ b/vendor/helm.sh/helm/v3/pkg/time/time.go
@@ -1,0 +1,91 @@
+/*
+Copyright The Helm Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package time contains a wrapper for time.Time in the standard library and
+// associated methods. This package mainly exists to workaround an issue in Go
+// where the serializer doesn't omit an empty value for time:
+// https://github.com/golang/go/issues/11939. As such, this can be removed if a
+// proposal is ever accepted for Go
+package time
+
+import (
+	"bytes"
+	"time"
+)
+
+// emptyString contains an empty JSON string value to be used as output
+var emptyString = `""`
+
+// Time is a convenience wrapper around stdlib time, but with different
+// marshalling and unmarshaling for zero values
+type Time struct {
+	time.Time
+}
+
+// Now returns the current time. It is a convenience wrapper around time.Now()
+func Now() Time {
+	return Time{time.Now()}
+}
+
+func (t Time) MarshalJSON() ([]byte, error) {
+	if t.Time.IsZero() {
+		return []byte(emptyString), nil
+	}
+
+	return t.Time.MarshalJSON()
+}
+
+func (t *Time) UnmarshalJSON(b []byte) error {
+	if bytes.Equal(b, []byte("null")) {
+		return nil
+	}
+	// If it is empty, we don't have to set anything since time.Time is not a
+	// pointer and will be set to the zero value
+	if bytes.Equal([]byte(emptyString), b) {
+		return nil
+	}
+
+	return t.Time.UnmarshalJSON(b)
+}
+
+func Parse(layout, value string) (Time, error) {
+	t, err := time.Parse(layout, value)
+	return Time{Time: t}, err
+}
+func ParseInLocation(layout, value string, loc *time.Location) (Time, error) {
+	t, err := time.ParseInLocation(layout, value, loc)
+	return Time{Time: t}, err
+}
+
+func Date(year int, month time.Month, day, hour, min, sec, nsec int, loc *time.Location) Time {
+	return Time{Time: time.Date(year, month, day, hour, min, sec, nsec, loc)}
+}
+
+func Unix(sec int64, nsec int64) Time { return Time{Time: time.Unix(sec, nsec)} }
+
+func (t Time) Add(d time.Duration) Time { return Time{Time: t.Time.Add(d)} }
+func (t Time) AddDate(years int, months int, days int) Time {
+	return Time{Time: t.Time.AddDate(years, months, days)}
+}
+func (t Time) After(u Time) bool             { return t.Time.After(u.Time) }
+func (t Time) Before(u Time) bool            { return t.Time.Before(u.Time) }
+func (t Time) Equal(u Time) bool             { return t.Time.Equal(u.Time) }
+func (t Time) In(loc *time.Location) Time    { return Time{Time: t.Time.In(loc)} }
+func (t Time) Local() Time                   { return Time{Time: t.Time.Local()} }
+func (t Time) Round(d time.Duration) Time    { return Time{Time: t.Time.Round(d)} }
+func (t Time) Sub(u Time) time.Duration      { return t.Time.Sub(u.Time) }
+func (t Time) Truncate(d time.Duration) Time { return Time{Time: t.Time.Truncate(d)} }
+func (t Time) UTC() Time                     { return Time{Time: t.Time.UTC()} }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -623,6 +623,9 @@ helm.sh/helm/v3/pkg/chart/loader
 helm.sh/helm/v3/pkg/chartutil
 helm.sh/helm/v3/pkg/engine
 helm.sh/helm/v3/pkg/ignore
+helm.sh/helm/v3/pkg/release
+helm.sh/helm/v3/pkg/releaseutil
+helm.sh/helm/v3/pkg/time
 # k8s.io/api v0.29.1
 ## explicit; go 1.21
 k8s.io/api/admission/v1


### PR DESCRIPTION
- In helm charts the namespace might not always be set in the manifest template. But it can be set using --namespace flag. This pr always sets the `agentInstallNamespace` to the objects rendered from helm charts
- Helm will sort objects by kind when applying to a cluster. This pr also follows/copies the same code to sort rendered objects.