### PR TITLE
🐛 Do not check addon status when the cluster availability is unknown

### DIFF
--- a/pkg/addonmanager/controllers/agentdeploy/healthcheck_sync.go
+++ b/pkg/addonmanager/controllers/agentdeploy/healthcheck_sync.go
@@ -105,6 +105,17 @@ func (s *healthCheckSyncer) probeDeploymentAvailabilityAddonStatus(
 func (s *healthCheckSyncer) probeAddonStatusByWorks(
 	cluster *clusterv1.ManagedCluster, addon *addonapiv1alpha1.ManagedClusterAddOn) error {
 
+	if cluster != nil {
+		clusterAvailableCondition := meta.FindStatusCondition(cluster.Status.Conditions,
+			clusterv1.ManagedClusterConditionAvailable)
+		if clusterAvailableCondition != nil && clusterAvailableCondition.Status == metav1.ConditionUnknown {
+			// if the managed cluster availability is unknown, skip the health check
+			// and the registration agent will set all addon status to unknown
+			// nolint see: https://github.com/open-cluster-management-io/ocm/blob/9dc8f104cf51439b6bb1f738894e75aabdf5f8dc/pkg/registration/hub/addon/healthcheck_controller.go#L68-L78
+			return nil
+		}
+	}
+
 	addonWorks, err := s.getWorkByAddon(addon.Name, addon.Namespace)
 	if err != nil || len(addonWorks) == 0 {
 		meta.SetStatusCondition(&addon.Status.Conditions, metav1.Condition{


### PR DESCRIPTION
Do not check addon status when the cluster availability is unknown, otherwise, when the cluster is unknown and the manifestwork feedback rule deployment available replica >1(was not updated after the cluster is unknown), the addon-framework will update the addon status to `True`, but the [registration-agent will update the addon status to `Unknown`](https://github.com/open-cluster-management-io/ocm/blob/9dc8f104cf51439b6bb1f738894e75aabdf5f8dc/pkg/registration/hub/addon/healthcheck_controller.go#L68-L78), which will lead to an infinite loop