### PR TITLE
🌱 Add a helper func to check if a managed cluster condition changes

### DIFF
--- a/pkg/utils/helpers.go
+++ b/pkg/utils/helpers.go
@@ -386,8 +386,36 @@ func MapValueChanged(old, new map[string]string, key string) bool {
 // ClusterImageRegistriesAnnotationChanged returns true if the value of the ClusterImageRegistriesAnnotationKey
 // in the new managed cluster annotation is different from the old managed cluster annotation
 func ClusterImageRegistriesAnnotationChanged(old, new *clusterv1.ManagedCluster) bool {
+	return ClusterAnnotationChanged(old, new, clusterv1.ClusterImageRegistriesAnnotationKey)
+}
+
+// ClusterAnnotationChanged returns true if the value of the specified annotation in the new managed cluster annotation
+// is different from the old managed cluster annotation
+func ClusterAnnotationChanged(old, new *clusterv1.ManagedCluster, annotation string) bool {
 	if new == nil || old == nil {
 		return false
 	}
-	return MapValueChanged(old.Annotations, new.Annotations, clusterv1.ClusterImageRegistriesAnnotationKey)
+	return MapValueChanged(old.Annotations, new.Annotations, annotation)
+}
+
+// ClusterAvailableConditionChanged returns true if the value of the Available condition in the new managed cluster
+// is different from the old managed cluster
+func ClusterAvailableConditionChanged(old, new *clusterv1.ManagedCluster) bool {
+	return ClusterConditionChanged(old, new, clusterv1.ManagedClusterConditionAvailable)
+}
+
+// ClusterAvailableConditionChanged returns true if the value of the specified conditionType in the new managed cluster
+// is different from the old managed cluster
+func ClusterConditionChanged(old, new *clusterv1.ManagedCluster, conditionType string) bool {
+	if new == nil || old == nil {
+		return false
+	}
+
+	oldAvailableCondition := meta.FindStatusCondition(old.Status.Conditions, conditionType)
+	newAvailableCondition := meta.FindStatusCondition(new.Status.Conditions, conditionType)
+
+	return (oldAvailableCondition == nil && newAvailableCondition != nil) ||
+		(oldAvailableCondition != nil && newAvailableCondition == nil) ||
+		(oldAvailableCondition != nil && newAvailableCondition != nil &&
+			oldAvailableCondition.Status != newAvailableCondition.Status)
 }

--- a/pkg/utils/helpers_test.go
+++ b/pkg/utils/helpers_test.go
@@ -243,3 +243,132 @@ func TestClusterImageRegistriesAnnotationChanged(t *testing.T) {
 		})
 	}
 }
+
+func TestClusterAvailableConditionChanged(t *testing.T) {
+	cases := []struct {
+		name     string
+		old      *clusterv1.ManagedCluster
+		new      *clusterv1.ManagedCluster
+		expected bool
+	}{
+		{
+			name: "condition not changed",
+			old: &clusterv1.ManagedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+				},
+				Status: clusterv1.ManagedClusterStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:    clusterv1.ManagedClusterConditionAvailable,
+							Status:  metav1.ConditionTrue,
+							Message: "test",
+						},
+					},
+				},
+			},
+			new: &clusterv1.ManagedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+				},
+				Status: clusterv1.ManagedClusterStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:    clusterv1.ManagedClusterConditionAvailable,
+							Status:  metav1.ConditionTrue,
+							Message: "message changed",
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "old condition not present",
+			old: &clusterv1.ManagedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+				},
+			},
+			new: &clusterv1.ManagedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+				},
+				Status: clusterv1.ManagedClusterStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:    clusterv1.ManagedClusterConditionAvailable,
+							Status:  metav1.ConditionTrue,
+							Message: "test",
+						},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "new condition not present",
+			old: &clusterv1.ManagedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+				},
+				Status: clusterv1.ManagedClusterStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:    clusterv1.ManagedClusterConditionAvailable,
+							Status:  metav1.ConditionUnknown,
+							Message: "test",
+						},
+					},
+				},
+			},
+			new: &clusterv1.ManagedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "condition changed",
+			old: &clusterv1.ManagedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+				},
+				Status: clusterv1.ManagedClusterStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:    clusterv1.ManagedClusterConditionAvailable,
+							Status:  metav1.ConditionUnknown,
+							Message: "test",
+						},
+					},
+				},
+			},
+			new: &clusterv1.ManagedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+				},
+				Status: clusterv1.ManagedClusterStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:    clusterv1.ManagedClusterConditionAvailable,
+							Status:  metav1.ConditionTrue,
+							Message: "test",
+						},
+					},
+				},
+			},
+			expected: true,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			actual := ClusterAvailableConditionChanged(c.old, c.new)
+			if actual != c.expected {
+				t.Errorf("name %s: expected %v, but got %v", c.name, c.expected, actual)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Add a helper func to check if a managed cluster condition changes, so users can use this to make the agent deploy controller watch if the managed cluster condition changes. 
related PR: https://github.com/open-cluster-management-io/addon-framework/pull/199
