### PR TITLE
:bug: fix deploying ocm error in e2e

### DIFF
--- a/examples/deploy/ocm/install.sh
+++ b/examples/deploy/ocm/install.sh
@@ -54,14 +54,14 @@ for i in {1..7}; do
 done
 
 for i in {1..7}; do
-  echo "############$i  Checking klusterlet-registration-agent"
-  RUNNING_POD=$($KUBECTL -n open-cluster-management-agent get pods | grep klusterlet-registration-agent | grep -c "Running")
+  echo "############$i  Checking klusterlet-agent"
+  RUNNING_POD=$($KUBECTL -n open-cluster-management-agent get pods | grep klusterlet-agent | grep -c "Running")
   if [ ${RUNNING_POD} -ge 1 ]; then
     break
   fi
 
   if [ $i -eq 7 ]; then
-    echo "!!!!!!!!!!  the klusterlet-registration-agent is not ready within 3 minutes"
+    echo "!!!!!!!!!!  the klusterlet-agent is not ready within 3 minutes"
     $KUBECTL -n open-cluster-management-agent get pods
     exit 1
   fi


### PR DESCRIPTION
The [PR in ocm repo](https://github.com/open-cluster-management-io/ocm/pull/365/files#diff-191c20bda57b28bc09dad6d2a883b7431ebf2aaae26c53828ca91bea09d25fa2R7) changed the default install mode to `Singleton`, so there will be only one `klusterlet-agent` on the manged cluster