### PR TITLE
🌱 Add a method to set the hosting cluster for the Helm agent

### DIFF
--- a/pkg/addonfactory/helm_agentaddon.go
+++ b/pkg/addonfactory/helm_agentaddon.go
@@ -219,6 +219,10 @@ func (a *HelmAgentAddon) getBuiltinValues(
 	return helmBuiltinValues, nil
 }
 
+func (a *HelmAgentAddon) SetHostingCluster(hostingCluster *clusterv1.ManagedCluster) {
+	a.hostingCluster = hostingCluster
+}
+
 func (a *HelmAgentAddon) getDefaultValues(
 	cluster *clusterv1.ManagedCluster,
 	addon *addonapiv1alpha1.ManagedClusterAddOn) (Values, error) {


### PR DESCRIPTION
The policy addons require setting this since we need the hosting cluster capabilities variables and we can't guarantee that the hosting cluster is static for each addon.