### PR TITLE
:bug: Fix: add a condition of manifestapplied for hosted addon.

### DIFF
--- a/pkg/addonmanager/controllers/agentdeploy/controller.go
+++ b/pkg/addonmanager/controllers/agentdeploy/controller.go
@@ -392,6 +392,12 @@ func (c *addonDeployController) buildDeployManifestWorksFunc(addonWorkBuilder *a
 			return nil, nil, err
 		}
 		if len(objects) == 0 {
+			meta.SetStatusCondition(&addon.Status.Conditions, metav1.Condition{
+				Type:    appliedType,
+				Status:  metav1.ConditionTrue,
+				Reason:  addonapiv1alpha1.AddonManifestAppliedReasonManifestsApplied,
+				Message: "no manifest need to apply",
+			})
 			return nil, nil, nil
 		}
 


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:rocket: 🚀 release
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

For hosted mode addons, there are no manifestwork need to be applied by default addondeploycontroller, we want to add a condition to state that.


