### PR TITLE
:bug: Fix condition error of ManifestApplied.

### DIFF
--- a/pkg/addonmanager/controllers/agentdeploy/controller.go
+++ b/pkg/addonmanager/controllers/agentdeploy/controller.go
@@ -391,15 +391,6 @@ func (c *addonDeployController) buildDeployManifestWorksFunc(addonWorkBuilder *a
 			})
 			return nil, nil, err
 		}
-		if len(objects) == 0 {
-			meta.SetStatusCondition(&addon.Status.Conditions, metav1.Condition{
-				Type:    appliedType,
-				Status:  metav1.ConditionTrue,
-				Reason:  addonapiv1alpha1.AddonManifestAppliedReasonManifestsApplied,
-				Message: "no manifest need to apply",
-			})
-			return nil, nil, nil
-		}
 
 		// this is to retrieve the intended mode of the addon.
 		var mode string
@@ -424,6 +415,14 @@ func (c *addonDeployController) buildDeployManifestWorksFunc(addonWorkBuilder *a
 				Message: fmt.Sprintf("failed to build manifestwork: %v", err),
 			})
 			return nil, nil, err
+		}
+		if len(appliedWorks) == 0 {
+			meta.SetStatusCondition(&addon.Status.Conditions, metav1.Condition{
+				Type:    appliedType,
+				Status:  metav1.ConditionTrue,
+				Reason:  addonapiv1alpha1.AddonManifestAppliedReasonManifestsApplied,
+				Message: "no manifest need to apply",
+			})
 		}
 		return appliedWorks, deleteWorks, nil
 	}

--- a/pkg/addonmanager/controllers/agentdeploy/hosted_sync_test.go
+++ b/pkg/addonmanager/controllers/agentdeploy/hosted_sync_test.go
@@ -237,6 +237,20 @@ func TestHostingReconcile(t *testing.T) {
 				if meta.IsStatusConditionFalse(addOn.Status.Conditions, addonapiv1alpha1.ManagedClusterAddOnHostingManifestApplied) {
 					t.Errorf("Condition Reason is not correct: %v", addOn.Status.Conditions)
 				}
+
+				manifestAppliyedCondition := meta.FindStatusCondition(addOn.Status.Conditions, addonapiv1alpha1.ManagedClusterAddOnManifestApplied)
+				if manifestAppliyedCondition == nil {
+					t.Fatal("manifestapplied condition should not be nil")
+				}
+				if manifestAppliyedCondition.Reason != addonapiv1alpha1.AddonManifestAppliedReasonManifestsApplied {
+					t.Errorf("Condition Reason is not correct: %v", manifestAppliyedCondition.Reason)
+				}
+				if manifestAppliyedCondition.Message != "no manifest need to apply" {
+					t.Errorf("Condition Message is not correct: %v", manifestAppliyedCondition.Message)
+				}
+				if manifestAppliyedCondition.Status != metav1.ConditionTrue {
+					t.Errorf("Condition Status is not correct: %v", manifestAppliyedCondition.Status)
+				}
 			},
 		},
 		{

--- a/test/integration/cloudevents/agent_hosting_deploy_test.go
+++ b/test/integration/cloudevents/agent_hosting_deploy_test.go
@@ -229,6 +229,20 @@ var _ = ginkgo.Describe("Agent deploy", func() {
 			if !meta.IsStatusConditionTrue(addon.Status.Conditions, addonapiv1alpha1.ManagedClusterAddOnHostingManifestApplied) {
 				return fmt.Errorf("Unexpected addon applied condition, %v", addon.Status.Conditions)
 			}
+
+			manifestAppliyedCondition := meta.FindStatusCondition(addon.Status.Conditions, addonapiv1alpha1.ManagedClusterAddOnManifestApplied)
+			if manifestAppliyedCondition == nil {
+				return fmt.Errorf("%s Condition is not found", addonapiv1alpha1.ManagedClusterAddOnManifestApplied)
+			}
+			if manifestAppliyedCondition.Reason != addonapiv1alpha1.AddonManifestAppliedReasonManifestsApplied {
+				return fmt.Errorf("Condition Reason is not correct: %v", manifestAppliyedCondition.Reason)
+			}
+			if manifestAppliyedCondition.Message != "no manifest need to apply" {
+				return fmt.Errorf("Condition Message is not correct: %v", manifestAppliyedCondition.Message)
+			}
+			if manifestAppliyedCondition.Status != metav1.ConditionTrue {
+				return fmt.Errorf("Condition Status is not correct: %v", manifestAppliyedCondition.Status)
+			}
 			return nil
 		}, eventuallyTimeout, eventuallyInterval).ShouldNot(gomega.HaveOccurred())
 


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:rocket: 🚀 release
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

This PR is related to the https://github.com/open-cluster-management-io/addon-framework/pull/268 

It turns out Manifests will always return objects, it's `BuildDeployWorks` to decide whether the objects is match to the current mode.

And this time I tested with a self-build image on the test env.
