### PR TITLE
🐛 Skip health check for deployments whose replicas is 0

### DIFF
--- a/pkg/addonmanager/controllers/agentdeploy/healthcheck_sync_test.go
+++ b/pkg/addonmanager/controllers/agentdeploy/healthcheck_sync_test.go
@@ -44,6 +44,7 @@ func (t *healthCheckTestAgent) Manifests(cluster *clusterv1.ManagedCluster,
 
 	return []runtime.Object{
 		NewFakeDeployment("test-deployment", "default"),
+		NewFakeZeroReplicasDeployment("test-zero-replicas-deployment", "default"),
 		NewFakeDaemonSet("test-daemonset", "default"),
 	}, nil
 }
@@ -64,6 +65,39 @@ func NewFakeDeployment(namespace, name string) *appsv1.Deployment {
 		},
 		Spec: appsv1.DeploymentSpec{
 			Replicas: &one,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"app": "test",
+				},
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"addon": "test",
+					},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "test",
+							Image: "test",
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func NewFakeZeroReplicasDeployment(namespace, name string) *appsv1.Deployment {
+	var zero int32 = 0
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      namespace,
+			Namespace: name,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &zero,
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					"app": "test",

--- a/pkg/utils/probe_helper.go
+++ b/pkg/utils/probe_helper.go
@@ -134,6 +134,11 @@ func FilterDeployments(objects []runtime.Object) []*appsv1.Deployment {
 type WorkloadMetadata struct {
 	schema.GroupResource
 	types.NamespacedName
+	DeploymentSpec *DeploymentSpec
+}
+
+type DeploymentSpec struct {
+	Replicas int32
 }
 
 func FilterWorkloads(objects []runtime.Object) []WorkloadMetadata {
@@ -149,6 +154,9 @@ func FilterWorkloads(objects []runtime.Object) []WorkloadMetadata {
 				NamespacedName: types.NamespacedName{
 					Namespace: deployment.Namespace,
 					Name:      deployment.Name,
+				},
+				DeploymentSpec: &DeploymentSpec{
+					Replicas: *deployment.Spec.Replicas,
 				},
 			})
 		}


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:rocket: 🚀 release
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

In some cases, we want to deploy a deployment resource whose replicas is 0 to the managed cluster, if we set the health probe type to "WorkloadAvailability", the addon can not become available since there is no probed result for 0 replicas deployments. In this situation, we want to make the health probe check pass for the addon.

## Related issue(s)

Fixes #
