### PR TITLE
:bug: include error in msg from healthchecker

### DIFF
--- a/pkg/addonmanager/controllers/agentdeploy/healthcheck_sync.go
+++ b/pkg/addonmanager/controllers/agentdeploy/healthcheck_sync.go
@@ -227,14 +227,16 @@ func (s *healthCheckSyncer) probeAddonStatusByWorks(
 
 	}
 
-	if healthChecker != nil && healthChecker(FieldResults, cluster, addon) != nil {
-		meta.SetStatusCondition(&addon.Status.Conditions, metav1.Condition{
-			Type:    addonapiv1alpha1.ManagedClusterAddOnConditionAvailable,
-			Status:  metav1.ConditionFalse,
-			Reason:  addonapiv1alpha1.AddonAvailableReasonProbeUnavailable,
-			Message: fmt.Sprintf("Probe addon unavailable with err %v", err),
-		})
-		return nil
+	if healthChecker != nil {
+		if err := healthChecker(FieldResults, cluster, addon); err != nil {
+			meta.SetStatusCondition(&addon.Status.Conditions, metav1.Condition{
+				Type:    addonapiv1alpha1.ManagedClusterAddOnConditionAvailable,
+				Status:  metav1.ConditionFalse,
+				Reason:  addonapiv1alpha1.AddonAvailableReasonProbeUnavailable,
+				Message: fmt.Sprintf("Probe addon unavailable with err %v", err),
+			})
+			return nil
+		}
 	}
 
 	meta.SetStatusCondition(&addon.Status.Conditions, metav1.Condition{


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:rocket: 🚀 release
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

Fixes issue where if a healthchecker function returns an error,  the message would not include the text from the error, instead we would see:

```
"Probe addon unavailable with err <nil>"
```

## Related issue(s)

Fixes # https://github.com/open-cluster-management-io/addon-framework/issues/295
