### PR TITLE
:bug:  patch the mca supportedconfigs when failed to get intallnamespace

### DIFF
--- a/pkg/addonmanager/controllers/addonconfig/controller.go
+++ b/pkg/addonmanager/controllers/addonconfig/controller.go
@@ -172,12 +172,9 @@ func (c *addonConfigController) sync(ctx context.Context, syncCtx factory.SyncCo
 }
 
 func (c *addonConfigController) updateConfigSpecHashAndGenerations(addon *addonapiv1alpha1.ManagedClusterAddOn) error {
-	supportedConfigSet := map[addonapiv1alpha1.ConfigGroupResource]bool{}
-	for _, config := range addon.Status.SupportedConfigs {
-		supportedConfigSet[config] = true
-	}
 	for index, configReference := range addon.Status.ConfigReferences {
 
+		// do not update for unsupported configs
 		if !utils.ContainGR(
 			c.configGVRs,
 			configReference.ConfigGroupResource.Group,
@@ -211,10 +208,6 @@ func (c *addonConfigController) updateConfigSpecHashAndGenerations(addon *addona
 
 		// update desired spec hash only for the configs in spec
 		for _, addonconfig := range addon.Spec.Configs {
-			// do not update spec hash for unsupported configs
-			if _, ok := supportedConfigSet[addonconfig.ConfigGroupResource]; !ok {
-				continue
-			}
 			if configReference.DesiredConfig == nil {
 				continue
 			}

--- a/pkg/addonmanager/controllers/addonconfig/controller_test.go
+++ b/pkg/addonmanager/controllers/addonconfig/controller_test.go
@@ -91,12 +91,6 @@ func TestSync(t *testing.T) {
 							},
 						},
 					}
-					addon.Status.SupportedConfigs = []addonapiv1alpha1.ConfigGroupResource{
-						{
-							Group:    fakeGVR.Group,
-							Resource: fakeGVR.Resource,
-						},
-					}
 					return addon
 				}(),
 			},
@@ -128,7 +122,7 @@ func TestSync(t *testing.T) {
 						{
 							ConfigGroupResource: addonapiv1alpha1.ConfigGroupResource{
 								Group:    fakeGVR.Group,
-								Resource: fakeGVR.Resource,
+								Resource: fakeGVR.Resource + "-unsupported",
 							},
 							ConfigReferent: addonapiv1alpha1.ConfigReferent{
 								Namespace: "cluster1",
@@ -140,13 +134,13 @@ func TestSync(t *testing.T) {
 						{
 							ConfigGroupResource: addonapiv1alpha1.ConfigGroupResource{
 								Group:    fakeGVR.Group,
-								Resource: fakeGVR.Resource,
+								Resource: fakeGVR.Resource + "-unsupported",
 							},
 							ConfigReferent: addonapiv1alpha1.ConfigReferent{
 								Namespace: "cluster1",
 								Name:      "test",
 							},
-							LastObservedGeneration: 1,
+							LastObservedGeneration: 0,
 							DesiredConfig: &addonapiv1alpha1.ConfigSpecHash{
 								ConfigReferent: addonapiv1alpha1.ConfigReferent{
 									Namespace: "cluster1",
@@ -160,20 +154,7 @@ func TestSync(t *testing.T) {
 			},
 			configs: []runtime.Object{newTestConfing("test", "cluster1", 2)},
 			validateActions: func(t *testing.T, actions []clienttesting.Action) {
-				patch := actions[0].(clienttesting.PatchActionImpl).Patch
-				addOn := &addonapiv1alpha1.ManagedClusterAddOn{}
-				err := json.Unmarshal(patch, addOn)
-				if err != nil {
-					t.Fatal(err)
-				}
-
-				if addOn.Status.ConfigReferences[0].LastObservedGeneration != 2 {
-					t.Errorf("Expect addon config generation is 2, but got %v", addOn.Status.ConfigReferences[0].LastObservedGeneration)
-				}
-
-				if addOn.Status.ConfigReferences[0].DesiredConfig.SpecHash != "" {
-					t.Errorf("Expect addon config spec hash is empty, but got %v", addOn.Status.ConfigReferences[0].DesiredConfig.SpecHash)
-				}
+				addontesting.AssertNoActions(t, actions)
 			},
 		},
 		{


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:rocket: 🚀 release
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
 Manually creating an addon with spec.configs set like below, the managedclusteraddon ConfigurationUnsupported condition shows "Configuration with gvr addon.open-cluster-management.io/addondeploymentconfigs is not supported for this addon"

```
# managedclusteraddon with spec.configs set
apiVersion: addon.open-cluster-management.io/v1alpha1
kind: ManagedClusterAddOn
metadata:
  name: gitops-addon
  namespace: local-cluster
spec:
  configs:
  - group: addon.open-cluster-management.io
    name: gitops-addon-config
    namespace: local-cluster
    resource: addondeploymentconfigs
  installNamespace: open-cluster-management-agent-addon 
```
```
# status
  conditions:
  - lastTransitionTime: "2025-01-24T09:55:59Z"
    message: Configurations configured
    reason: ConfigurationsConfigured
    status: "True"
    type: Configured
  - lastTransitionTime: "2025-01-24T09:55:59Z"
    message: Configuration with gvr addon.open-cluster-management.io/addondeploymentconfigs
      is not supported for this addon
    reason: ConfigurationUnsupported
    status: "False"
    type: Progressing
  - lastTransitionTime: "2025-01-24T09:56:02Z"
    message: The status of gitops-addon add-on is unknown.
    reason: ManagedClusterAddOnLeaseNotFound
    status: Unknown
    type: Available
  configReferences:
  - desiredConfig:
      name: gitops-addon-config
      namespace: local-cluster
      specHash: ""
    group: addon.open-cluster-management.io
    lastObservedGeneration: 1
    name: gitops-addon-config
    namespace: local-cluster
    resource: addondeploymentconfigs
  - desiredConfig:
      name: gitops-addon
      specHash: 2a4f983141e9ea3ce3d2ebcbe62cda6f367a41a119ed1733cc540965e4d62059
    group: addon.open-cluster-management.io
    lastObservedGeneration: 1
    name: gitops-addon
    resource: addontemplates 
```

 
 

## Related issue(s)

Fixes #
1. Refine the registration controller, still patch mca supportedconfigs when failed to get install namespace.
2. When updating the spec hash of cma and mca, c.configGVRs is the only source of truth to check if config is supported, does not depend on status.supportedconfigs any more. 
