### PR TITLE
:warning: breaking change: when annotation is empty default managed by addon-manager

### DIFF
--- a/pkg/utils/helpers.go
+++ b/pkg/utils/helpers.go
@@ -296,37 +296,15 @@ func ManagedByAddonManager(obj interface{}) bool {
 	accessor, _ := meta.Accessor(obj)
 	annotations := accessor.GetAnnotations()
 	if len(annotations) == 0 {
-		return false
+		return true
 	}
 
 	value, ok := annotations[addonapiv1alpha1.AddonLifecycleAnnotationKey]
 	if !ok {
-		return false
+		return true
 	}
 
 	return value == addonapiv1alpha1.AddonLifecycleAddonManagerAnnotationValue
-}
-
-func ManagedBySelf(agentAddons map[string]agent.AgentAddon) func(obj interface{}) bool {
-	return func(obj interface{}) bool {
-		accessor, _ := meta.Accessor(obj)
-		if _, ok := agentAddons[accessor.GetName()]; !ok {
-			return false
-		}
-
-		annotations := accessor.GetAnnotations()
-
-		if len(annotations) == 0 {
-			return true
-		}
-
-		value, ok := annotations[addonapiv1alpha1.AddonLifecycleAnnotationKey]
-		if !ok {
-			return true
-		}
-
-		return value == addonapiv1alpha1.AddonLifecycleSelfManageAnnotationValue
-	}
 }
 
 func FilterByAddonName(agentAddons map[string]agent.AgentAddon) func(obj interface{}) bool {


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:rocket: 🚀 release
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

## Related issue(s)

Ref: https://github.com/open-cluster-management-io/ocm/issues/510 
