### PR TITLE
🌱 Expose GetRegexResourceRequirements func

### DIFF
--- a/pkg/addonfactory/addondeploymentconfig_test.go
+++ b/pkg/addonfactory/addondeploymentconfig_test.go
@@ -260,36 +260,36 @@ func TestGetAddOnDeploymentConfigValues(t *testing.T) {
 				},
 			},
 			expectedValues: Values{
-				"ResourceRequirements": []regexResourceRequirements{
+				"ResourceRequirements": []RegexResourceRequirements{
 					{
 						ContainerIDRegex: "^a:b:c$",
-						Resources: resourceRequirements{
-							Requests: map[string]string{
-								"memory": "64Mi",
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceMemory: resource.MustParse("64Mi"),
 							},
 						},
 					},
 					{
 						ContainerIDRegex: "^.+:b:c$",
-						Resources: resourceRequirements{
-							Requests: map[string]string{
-								"memory": "128Mi",
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceMemory: resource.MustParse("128Mi"),
 							},
 						},
 					},
 					{
 						ContainerIDRegex: "^.+:.+:c$",
-						Resources: resourceRequirements{
-							Requests: map[string]string{
-								"memory": "256Mi",
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceMemory: resource.MustParse("256Mi"),
 							},
 						},
 					},
 					{
 						ContainerIDRegex: "^.+:.+:.+$",
-						Resources: resourceRequirements{
-							Requests: map[string]string{
-								"memory": "512Mi",
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceMemory: resource.MustParse("512Mi"),
 							},
 						},
 					},
@@ -728,19 +728,19 @@ func TestGetRegexResourceRequirements(t *testing.T) {
 			corev1.ResourceMemory: resource.MustParse("256Mi"),
 		},
 	}
-	expectedReqirement := resourceRequirements{
-		Requests: map[string]string{
-			"memory": "128Mi",
+	expectedReqirement := corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceMemory: resource.MustParse("128Mi"),
 		},
-		Limits: map[string]string{
-			"memory": "256Mi",
+		Limits: corev1.ResourceList{
+			corev1.ResourceMemory: resource.MustParse("256Mi"),
 		},
 	}
 
 	cases := []struct {
 		name                          string
 		containerResourceRequirements []addonapiv1alpha1.ContainerResourceRequirements
-		expectedResourceRequirements  []regexResourceRequirements
+		expectedResourceRequirements  []RegexResourceRequirements
 		expectedErr                   error
 	}{
 		{
@@ -764,7 +764,7 @@ func TestGetRegexResourceRequirements(t *testing.T) {
 					Resources:   reqirement,
 				},
 			},
-			expectedResourceRequirements: []regexResourceRequirements{
+			expectedResourceRequirements: []RegexResourceRequirements{
 				{
 					ContainerIDRegex: "^a:b:c$",
 					Resources:        expectedReqirement,
@@ -779,7 +779,7 @@ func TestGetRegexResourceRequirements(t *testing.T) {
 					Resources:   reqirement,
 				},
 			},
-			expectedResourceRequirements: []regexResourceRequirements{
+			expectedResourceRequirements: []RegexResourceRequirements{
 				{
 					ContainerIDRegex: "^.+:b:c$",
 					Resources:        expectedReqirement,
@@ -794,7 +794,7 @@ func TestGetRegexResourceRequirements(t *testing.T) {
 					Resources:   reqirement,
 				},
 			},
-			expectedResourceRequirements: []regexResourceRequirements{
+			expectedResourceRequirements: []RegexResourceRequirements{
 				{
 					ContainerIDRegex: "^.+:.+:c$",
 					Resources:        expectedReqirement,
@@ -809,7 +809,7 @@ func TestGetRegexResourceRequirements(t *testing.T) {
 					Resources:   reqirement,
 				},
 			},
-			expectedResourceRequirements: []regexResourceRequirements{
+			expectedResourceRequirements: []RegexResourceRequirements{
 				{
 					ContainerIDRegex: "^.+:.+:.+$",
 					Resources:        expectedReqirement,
@@ -821,7 +821,7 @@ func TestGetRegexResourceRequirements(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 
-			requirements, err := getRegexResourceRequirements(c.containerResourceRequirements)
+			requirements, err := GetRegexResourceRequirements(c.containerResourceRequirements)
 			if err != nil {
 				if c.expectedErr == nil || !strings.EqualFold(err.Error(), c.expectedErr.Error()) {
 					t.Errorf("expected error %v, but got error %s", c.expectedErr, err)

--- a/pkg/addonfactory/addondeploymentconfig_test.go
+++ b/pkg/addonfactory/addondeploymentconfig_test.go
@@ -263,7 +263,12 @@ func TestGetAddOnDeploymentConfigValues(t *testing.T) {
 				"ResourceRequirements": []RegexResourceRequirements{
 					{
 						ContainerIDRegex: "^a:b:c$",
-						Resources: corev1.ResourceRequirements{
+						Resources: resourceRequirements{
+							Requests: map[string]string{
+								"memory": "64Mi",
+							},
+						},
+						ResourcesRaw: corev1.ResourceRequirements{
 							Requests: corev1.ResourceList{
 								corev1.ResourceMemory: resource.MustParse("64Mi"),
 							},
@@ -271,7 +276,12 @@ func TestGetAddOnDeploymentConfigValues(t *testing.T) {
 					},
 					{
 						ContainerIDRegex: "^.+:b:c$",
-						Resources: corev1.ResourceRequirements{
+						Resources: resourceRequirements{
+							Requests: map[string]string{
+								"memory": "128Mi",
+							},
+						},
+						ResourcesRaw: corev1.ResourceRequirements{
 							Requests: corev1.ResourceList{
 								corev1.ResourceMemory: resource.MustParse("128Mi"),
 							},
@@ -279,7 +289,12 @@ func TestGetAddOnDeploymentConfigValues(t *testing.T) {
 					},
 					{
 						ContainerIDRegex: "^.+:.+:c$",
-						Resources: corev1.ResourceRequirements{
+						Resources: resourceRequirements{
+							Requests: map[string]string{
+								"memory": "256Mi",
+							},
+						},
+						ResourcesRaw: corev1.ResourceRequirements{
 							Requests: corev1.ResourceList{
 								corev1.ResourceMemory: resource.MustParse("256Mi"),
 							},
@@ -287,7 +302,12 @@ func TestGetAddOnDeploymentConfigValues(t *testing.T) {
 					},
 					{
 						ContainerIDRegex: "^.+:.+:.+$",
-						Resources: corev1.ResourceRequirements{
+						Resources: resourceRequirements{
+							Requests: map[string]string{
+								"memory": "512Mi",
+							},
+						},
+						ResourcesRaw: corev1.ResourceRequirements{
 							Requests: corev1.ResourceList{
 								corev1.ResourceMemory: resource.MustParse("512Mi"),
 							},
@@ -728,7 +748,15 @@ func TestGetRegexResourceRequirements(t *testing.T) {
 			corev1.ResourceMemory: resource.MustParse("256Mi"),
 		},
 	}
-	expectedReqirement := corev1.ResourceRequirements{
+	expectedReqirement := resourceRequirements{
+		Requests: map[string]string{
+			"memory": "128Mi",
+		},
+		Limits: map[string]string{
+			"memory": "256Mi",
+		},
+	}
+	expectedReqirementRaw := corev1.ResourceRequirements{
 		Requests: corev1.ResourceList{
 			corev1.ResourceMemory: resource.MustParse("128Mi"),
 		},
@@ -768,6 +796,7 @@ func TestGetRegexResourceRequirements(t *testing.T) {
 				{
 					ContainerIDRegex: "^a:b:c$",
 					Resources:        expectedReqirement,
+					ResourcesRaw:     expectedReqirementRaw,
 				},
 			},
 		},
@@ -783,6 +812,7 @@ func TestGetRegexResourceRequirements(t *testing.T) {
 				{
 					ContainerIDRegex: "^.+:b:c$",
 					Resources:        expectedReqirement,
+					ResourcesRaw:     expectedReqirementRaw,
 				},
 			},
 		},
@@ -798,6 +828,7 @@ func TestGetRegexResourceRequirements(t *testing.T) {
 				{
 					ContainerIDRegex: "^.+:.+:c$",
 					Resources:        expectedReqirement,
+					ResourcesRaw:     expectedReqirementRaw,
 				},
 			},
 		},
@@ -813,6 +844,7 @@ func TestGetRegexResourceRequirements(t *testing.T) {
 				{
 					ContainerIDRegex: "^.+:.+:.+$",
 					Resources:        expectedReqirement,
+					ResourcesRaw:     expectedReqirementRaw,
 				},
 			},
 		},

--- a/pkg/addonfactory/template_agentaddon_test.go
+++ b/pkg/addonfactory/template_agentaddon_test.go
@@ -158,12 +158,12 @@ func TestTemplateAddon_Manifests(t *testing.T) {
 			getValuesFunc: func(cluster *clusterv1.ManagedCluster,
 				addon *addonapiv1alpha1.ManagedClusterAddOn) (Values, error) {
 				return Values{
-					"ResourceRequirements": []regexResourceRequirements{
+					"ResourceRequirements": []RegexResourceRequirements{
 						{
 							ContainerIDRegex: "^.+:.+:.+$",
-							Resources: resourceRequirements{
-								Requests: map[string]string{
-									"memory": "64Mi",
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceMemory: resource.MustParse("64Mi"),
 								},
 							},
 						},

--- a/pkg/addonfactory/template_agentaddon_test.go
+++ b/pkg/addonfactory/template_agentaddon_test.go
@@ -161,9 +161,9 @@ func TestTemplateAddon_Manifests(t *testing.T) {
 					"ResourceRequirements": []RegexResourceRequirements{
 						{
 							ContainerIDRegex: "^.+:.+:.+$",
-							Resources: corev1.ResourceRequirements{
-								Requests: corev1.ResourceList{
-									corev1.ResourceMemory: resource.MustParse("64Mi"),
+							Resources: resourceRequirements{
+								Requests: map[string]string{
+									"memory": "64Mi",
 								},
 							},
 						},


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:rocket: 🚀 release
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

- Expose GetRegexResourceRequirements func, so ocm repo can use it
- add a return value corev1.ResourceRequirements for the GetRegexResourceRequirements func
- refactor `ConvertToDeployment` and `ConvertToDaemonSet`

## Related issue(s)

Fixes #
