### PR TITLE
🌱 Deprecate work healthCheck use healthChecker instead

### DIFF
--- a/pkg/addonmanager/controllers/agentdeploy/healthcheck_sync.go
+++ b/pkg/addonmanager/controllers/agentdeploy/healthcheck_sync.go
@@ -191,6 +191,19 @@ func (s *healthCheckSyncer) probeAddonStatusByWorks(
 
 	for _, field := range probeFields {
 		results := findResultsByIdentifier(field.ResourceIdentifier, manifestConditions)
+		// if no results are returned. it is possible that work agent has not returned the feedback value.
+		// mark condition to unknown
+		if len(results) == 0 {
+			meta.SetStatusCondition(&addon.Status.Conditions, metav1.Condition{
+				Type:   addonapiv1alpha1.ManagedClusterAddOnConditionAvailable,
+				Status: metav1.ConditionUnknown,
+				Reason: addonapiv1alpha1.AddonAvailableReasonNoProbeResult,
+				Message: fmt.Sprintf("Probe results are not returned for %s/%s: %s/%s",
+					field.ResourceIdentifier.Group, field.ResourceIdentifier.Resource,
+					field.ResourceIdentifier.Namespace, field.ResourceIdentifier.Name),
+			})
+			return nil
+		}
 
 		// healthCheck will be ignored if healthChecker is set
 		if healthChecker != nil {
@@ -206,20 +219,6 @@ func (s *healthCheckSyncer) probeAddonStatusByWorks(
 				Status:  metav1.ConditionFalse,
 				Reason:  addonapiv1alpha1.AddonAvailableReasonProbeUnavailable,
 				Message: fmt.Sprintf("health checker function is not set %v", err),
-			})
-			return nil
-		}
-
-		// if no results are returned. it is possible that work agent has not returned the feedback value.
-		// mark condition to unknown
-		if len(results) == 0 {
-			meta.SetStatusCondition(&addon.Status.Conditions, metav1.Condition{
-				Type:   addonapiv1alpha1.ManagedClusterAddOnConditionAvailable,
-				Status: metav1.ConditionUnknown,
-				Reason: addonapiv1alpha1.AddonAvailableReasonNoProbeResult,
-				Message: fmt.Sprintf("Probe results are not returned for %s/%s: %s/%s",
-					field.ResourceIdentifier.Group, field.ResourceIdentifier.Resource,
-					field.ResourceIdentifier.Namespace, field.ResourceIdentifier.Name),
 			})
 			return nil
 		}
@@ -275,11 +274,11 @@ func (s *healthCheckSyncer) analyzeWorkProber(
 		}
 		return nil, nil, nil, fmt.Errorf("work prober is not configured")
 	case agent.HealthProberTypeDeploymentAvailability:
-		probeFields, heathCheck, err := s.analyzeDeploymentWorkProber(agentAddon, cluster, addon)
-		return probeFields, heathCheck, nil, err
+		probeFields, heathChecker, err := s.analyzeDeploymentWorkProber(agentAddon, cluster, addon)
+		return probeFields, nil, heathChecker, err
 	case agent.HealthProberTypeWorkloadAvailability:
-		probeFields, heathCheck, err := s.analyzeWorkloadsWorkProber(agentAddon, cluster, addon)
-		return probeFields, heathCheck, nil, err
+		probeFields, heathChecker, err := s.analyzeWorkloadsWorkProber(agentAddon, cluster, addon)
+		return probeFields, nil, heathChecker, err
 	default:
 		return nil, nil, nil, fmt.Errorf("unsupported health prober type %s", agentAddon.GetAgentAddonOptions().HealthProber.Type)
 	}
@@ -289,7 +288,7 @@ func (s *healthCheckSyncer) analyzeDeploymentWorkProber(
 	agentAddon agent.AgentAddon,
 	cluster *clusterv1.ManagedCluster,
 	addon *addonapiv1alpha1.ManagedClusterAddOn,
-) ([]agent.ProbeField, agent.AddonHealthCheckFunc, error) {
+) ([]agent.ProbeField, agent.AddonHealthCheckerFunc, error) {
 	probeFields := []agent.ProbeField{}
 
 	manifests, err := agentAddon.Manifests(cluster, addon)
@@ -310,14 +309,14 @@ func (s *healthCheckSyncer) analyzeDeploymentWorkProber(
 		})
 	}
 
-	return probeFields, utils.DeploymentAvailabilityHealthCheck, nil
+	return probeFields, utils.DeploymentAvailabilityHealthChecker, nil
 }
 
 func (s *healthCheckSyncer) analyzeWorkloadsWorkProber(
 	agentAddon agent.AgentAddon,
 	cluster *clusterv1.ManagedCluster,
 	addon *addonapiv1alpha1.ManagedClusterAddOn,
-) ([]agent.ProbeField, agent.AddonHealthCheckFunc, error) {
+) ([]agent.ProbeField, agent.AddonHealthCheckerFunc, error) {
 	probeFields := []agent.ProbeField{}
 
 	manifests, err := agentAddon.Manifests(cluster, addon)
@@ -344,7 +343,7 @@ func (s *healthCheckSyncer) analyzeWorkloadsWorkProber(
 		})
 	}
 
-	return probeFields, utils.WorkloadAvailabilityHealthCheck, nil
+	return probeFields, utils.WorkloadAvailabilityHealthChecker, nil
 }
 
 func findResultsByIdentifier(identifier workapiv1.ResourceIdentifier,

--- a/pkg/addonmanager/controllers/agentdeploy/healthcheck_sync_test.go
+++ b/pkg/addonmanager/controllers/agentdeploy/healthcheck_sync_test.go
@@ -2,7 +2,6 @@ package agentdeploy
 
 import (
 	"context"
-	"fmt"
 	"testing"
 	"time"
 
@@ -454,7 +453,22 @@ func TestHealthCheckReconcile(t *testing.T) {
 										Name:      "test-deployment1",
 										Namespace: "default",
 									},
-									StatusFeedbacks: v1.StatusFeedbackResult{},
+									StatusFeedbacks: v1.StatusFeedbackResult{
+										Values: []v1.FeedbackValue{
+											{
+												Name: "Replicas",
+												Value: v1.FieldValue{
+													Integer: boolPtr(1),
+												},
+											},
+											{
+												Name: "ReadyReplicas",
+												Value: v1.FieldValue{
+													Integer: boolPtr(2),
+												},
+											},
+										},
+									},
 								},
 							},
 						},
@@ -532,7 +546,22 @@ func TestHealthCheckReconcile(t *testing.T) {
 										Name:      "test-deployment1",
 										Namespace: "default",
 									},
-									StatusFeedbacks: v1.StatusFeedbackResult{},
+									StatusFeedbacks: v1.StatusFeedbackResult{
+										Values: []v1.FeedbackValue{
+											{
+												Name: "Replicas",
+												Value: v1.FieldValue{
+													Integer: boolPtr(1),
+												},
+											},
+											{
+												Name: "ReadyReplicas",
+												Value: v1.FieldValue{
+													Integer: boolPtr(2),
+												},
+											},
+										},
+									},
 								},
 							},
 						},
@@ -1298,20 +1327,6 @@ func TestHealthCheckReconcile(t *testing.T) {
 	}
 }
 
-func addonHealthCheckAllFunc(resultFields []agent.FieldResult, cluster *clusterv1.ManagedCluster,
-	addon *addonapiv1alpha1.ManagedClusterAddOn) error {
-	for _, field := range resultFields {
-		switch field.ResourceIdentifier.Resource {
-		case "deployments":
-			err := utils.DeploymentAvailabilityHealthCheck(field.ResourceIdentifier, field.FeedbackResult)
-			if err == nil {
-				return nil
-			}
-		}
-	}
-	return fmt.Errorf("not meet the results")
-}
-
 func newDeploymentsCheckAllProber(deployments ...types.NamespacedName) *agent.HealthProber {
 	probeFields := []agent.ProbeField{}
 	for _, deploy := range deployments {
@@ -1325,7 +1340,7 @@ func newDeploymentsCheckAllProber(deployments ...types.NamespacedName) *agent.He
 		Type: agent.HealthProberTypeWork,
 		WorkProber: &agent.WorkHealthProber{
 			ProbeFields:   probeFields,
-			HealthChecker: addonHealthCheckAllFunc,
+			HealthChecker: utils.DeploymentAvailabilityHealthChecker,
 		},
 	}
 }

--- a/pkg/agent/inteface.go
+++ b/pkg/agent/inteface.go
@@ -178,6 +178,7 @@ type WorkHealthProber struct {
 	// HealthCheck is deprecated and will be removed in the future. please use HealthChecker instead.
 	// HealthCheck will be ignored if HealthChecker is set.
 	// HealthCheck check status of the addon based on each probeField result.
+	// Deprecated: use HealthChecker instead.
 	HealthCheck AddonHealthCheckFunc
 
 	// HealthChecker check status of the addon based of all results of probeFields

--- a/pkg/utils/probe_helper.go
+++ b/pkg/utils/probe_helper.go
@@ -9,7 +9,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"open-cluster-management.io/addon-framework/pkg/agent"
-	"open-cluster-management.io/api/addon/v1alpha1"
+	addonapiv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
 	workapiv1 "open-cluster-management.io/api/work/v1"
 )
@@ -32,8 +32,8 @@ func NewDeploymentProber(deployments ...types.NamespacedName) *agent.HealthProbe
 	return &agent.HealthProber{
 		Type: agent.HealthProberTypeWork,
 		WorkProber: &agent.WorkHealthProber{
-			ProbeFields: probeFields,
-			HealthCheck: DeploymentAvailabilityHealthCheck,
+			ProbeFields:   probeFields,
+			HealthChecker: DeploymentAvailabilityHealthChecker,
 		},
 	}
 }
@@ -59,7 +59,7 @@ func NewAllDeploymentsProber() *agent.HealthProber {
 		Type: agent.HealthProberTypeWork,
 		WorkProber: &agent.WorkHealthProber{
 			ProbeFields:   probeFields,
-			HealthChecker: AllDeploymentsAvailabilityHealthCheck,
+			HealthChecker: DeploymentAvailabilityHealthChecker,
 		},
 	}
 }
@@ -84,26 +84,43 @@ func (d *DeploymentProber) ProbeFields() []agent.ProbeField {
 	return probeFields
 }
 
+// Deprecated: use DeploymentAvailabilityHealthChecker instead.
 func DeploymentAvailabilityHealthCheck(identifier workapiv1.ResourceIdentifier,
 	result workapiv1.StatusFeedbackResult) error {
-	return WorkloadAvailabilityHealthCheck(identifier, result)
+	return checkWorkloadAvailabilityHealth(identifier, result)
 }
 
+// Deprecated: use DeploymentAvailabilityHealthChecker instead.
 func AllDeploymentsAvailabilityHealthCheck(results []agent.FieldResult,
-	cluster *clusterv1.ManagedCluster, addon *v1alpha1.ManagedClusterAddOn) error {
+	cluster *clusterv1.ManagedCluster, addon *addonapiv1alpha1.ManagedClusterAddOn) error {
 	if len(results) < 2 {
 		return fmt.Errorf("all deployments are not available")
 	}
 
 	for _, result := range results {
-		if err := WorkloadAvailabilityHealthCheck(result.ResourceIdentifier, result.FeedbackResult); err != nil {
+		if err := checkWorkloadAvailabilityHealth(result.ResourceIdentifier, result.FeedbackResult); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func WorkloadAvailabilityHealthCheck(identifier workapiv1.ResourceIdentifier,
+func DeploymentAvailabilityHealthChecker(results []agent.FieldResult,
+	cluster *clusterv1.ManagedCluster, addon *addonapiv1alpha1.ManagedClusterAddOn) error {
+	return WorkloadAvailabilityHealthChecker(results, cluster, addon)
+}
+
+func WorkloadAvailabilityHealthChecker(results []agent.FieldResult,
+	cluster *clusterv1.ManagedCluster, addon *addonapiv1alpha1.ManagedClusterAddOn) error {
+	for _, result := range results {
+		if err := checkWorkloadAvailabilityHealth(result.ResourceIdentifier, result.FeedbackResult); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func checkWorkloadAvailabilityHealth(identifier workapiv1.ResourceIdentifier,
 	result workapiv1.StatusFeedbackResult) error {
 	// only support deployments and daemonsets for now
 	if identifier.Resource != "deployments" && identifier.Resource != "daemonsets" {

--- a/pkg/utils/probe_helper_test.go
+++ b/pkg/utils/probe_helper_test.go
@@ -8,6 +8,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"open-cluster-management.io/addon-framework/pkg/agent"
 	workapiv1 "open-cluster-management.io/api/work/v1"
 )
 
@@ -113,8 +114,12 @@ func TestDeploymentProbe(t *testing.T) {
 			prober := NewDeploymentProber(types.NamespacedName{Name: "test", Namespace: "testns"})
 
 			fields := prober.WorkProber.ProbeFields
-
-			err := prober.WorkProber.HealthCheck(fields[0].ResourceIdentifier, c.result)
+			err := prober.WorkProber.HealthChecker([]agent.FieldResult{
+				{
+					ResourceIdentifier: fields[0].ResourceIdentifier,
+					FeedbackResult:     c.result,
+				},
+			}, nil, nil)
 			if err != nil && err.Error() != c.expectedErr {
 				t.Errorf("expected error %s but got %v", c.expectedErr, err)
 			}

--- a/test/integration/kube/agent_deploy_test.go
+++ b/test/integration/kube/agent_deploy_test.go
@@ -922,7 +922,8 @@ var _ = ginkgo.Describe("Agent deploy", func() {
 				return err
 			}
 
-			if !meta.IsStatusConditionFalse(addon.Status.Conditions, "Available") {
+			// the daemonset is not probed, so the addon available condition is unknown
+			if !meta.IsStatusConditionPresentAndEqual(addon.Status.Conditions, "Available", metav1.ConditionUnknown) {
 				return fmt.Errorf("Unexpected addon available condition, %v", addon.Status.Conditions)
 			}
 			return nil


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:rocket: 🚀 release
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

## Related issue(s)

Fixes #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated health check logic to use new health checker functions, replacing deprecated ones for deployment and workload probes.
  * Deprecated older health check methods and updated related documentation to guide users to the new approach.

* **Bug Fixes**
  * Improved consistency and reliability of health status reporting for deployments and workloads.
  * Adjusted addon availability status to reflect unknown condition when no probe results are found.

* **Chores**
  * Updated internal references and removed obsolete code to streamline health check functionality.
  * Enhanced test coverage by refining deployment health check test data and updating test methods.
  * Marked deprecated fields clearly to improve code maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->