### PR TITLE
⚠️ Update CSR interfaces to support enhanced context and error handling

### DIFF
--- a/pkg/addonmanager/controllers/certificate/csrsign.go
+++ b/pkg/addonmanager/controllers/certificate/csrsign.go
@@ -138,7 +138,7 @@ func (c *csrSignController) sync(ctx context.Context, syncCtx factory.SyncContex
 
 	csr.Status.Certificate, err = registrationOption.CSRSign(cluster, addon, csr)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to sign addon csr %q: %v", csr.Name, err)
 	}
 	if len(csr.Status.Certificate) == 0 {
 		return fmt.Errorf("invalid client certificate generated for addon csr %q", csr.Name)

--- a/pkg/addonmanager/controllers/certificate/csrsign.go
+++ b/pkg/addonmanager/controllers/certificate/csrsign.go
@@ -116,7 +116,7 @@ func (c *csrSignController) sync(ctx context.Context, syncCtx factory.SyncContex
 	}
 
 	// Get ManagedCluster
-	_, err = c.managedClusterLister.Get(clusterName)
+	cluster, err := c.managedClusterLister.Get(clusterName)
 	if errors.IsNotFound(err) {
 		return nil
 	}
@@ -124,7 +124,7 @@ func (c *csrSignController) sync(ctx context.Context, syncCtx factory.SyncContex
 		return err
 	}
 
-	_, err = c.managedClusterAddonLister.ManagedClusterAddOns(clusterName).Get(addonName)
+	addon, err := c.managedClusterAddonLister.ManagedClusterAddOns(clusterName).Get(addonName)
 	if errors.IsNotFound(err) {
 		return nil
 	}
@@ -136,7 +136,10 @@ func (c *csrSignController) sync(ctx context.Context, syncCtx factory.SyncContex
 		return nil
 	}
 
-	csr.Status.Certificate = registrationOption.CSRSign(csr)
+	csr.Status.Certificate, err = registrationOption.CSRSign(cluster, addon, csr)
+	if err != nil {
+		return err
+	}
 	if len(csr.Status.Certificate) == 0 {
 		return fmt.Errorf("invalid client certificate generated for addon csr %q", csr.Name)
 	}

--- a/pkg/addonmanager/controllers/certificate/csrsign_test.go
+++ b/pkg/addonmanager/controllers/certificate/csrsign_test.go
@@ -34,8 +34,9 @@ func (t *testSignAgent) GetAgentAddonOptions() agent.AgentAddonOptions {
 	return agent.AgentAddonOptions{
 		AddonName: t.name,
 		Registration: &agent.RegistrationOption{
-			CSRSign: func(csr *certv1.CertificateSigningRequest) []byte {
-				return t.cert
+			CSRSign: func(cluster *clusterv1.ManagedCluster, addon *addonapiv1alpha1.ManagedClusterAddOn,
+				csr *certv1.CertificateSigningRequest) ([]byte, error) {
+				return t.cert, nil
 			},
 		},
 	}

--- a/pkg/addonmanager/controllers/registration/controller.go
+++ b/pkg/addonmanager/controllers/registration/controller.go
@@ -163,7 +163,7 @@ func (c *addonRegistrationController) sync(ctx context.Context, syncCtx factory.
 		return err
 	}
 
-	configs, err := registrationOption.CSRConfigurations(managedCluster)
+	configs, err := registrationOption.CSRConfigurations(managedCluster, managedClusterAddonCopy)
 	if err != nil {
 		return fmt.Errorf("get csr configurations failed: %v", err)
 	}

--- a/pkg/addonmanager/controllers/registration/controller.go
+++ b/pkg/addonmanager/controllers/registration/controller.go
@@ -163,7 +163,10 @@ func (c *addonRegistrationController) sync(ctx context.Context, syncCtx factory.
 		return err
 	}
 
-	configs := registrationOption.CSRConfigurations(managedCluster)
+	configs, err := registrationOption.CSRConfigurations(managedCluster)
+	if err != nil {
+		return fmt.Errorf("get csr configurations failed: %v", err)
+	}
 	managedClusterAddonCopy.Status.Registrations = configs
 
 	var agentInstallNamespace string

--- a/pkg/addonmanager/controllers/registration/controller_test.go
+++ b/pkg/addonmanager/controllers/registration/controller_test.go
@@ -42,8 +42,8 @@ func (t *testAgent) GetAgentAddonOptions() agent.AgentAddonOptions {
 	agentOption := agent.AgentAddonOptions{
 		AddonName: t.name,
 		Registration: &agent.RegistrationOption{
-			CSRConfigurations: func(cluster *clusterv1.ManagedCluster) []addonapiv1alpha1.RegistrationConfig {
-				return t.registrations
+			CSRConfigurations: func(cluster *clusterv1.ManagedCluster) ([]addonapiv1alpha1.RegistrationConfig, error) {
+				return t.registrations, nil
 			},
 			PermissionConfig: func(cluster *clusterv1.ManagedCluster, addon *addonapiv1alpha1.ManagedClusterAddOn) error {
 				return nil

--- a/pkg/addonmanager/controllers/registration/controller_test.go
+++ b/pkg/addonmanager/controllers/registration/controller_test.go
@@ -42,7 +42,7 @@ func (t *testAgent) GetAgentAddonOptions() agent.AgentAddonOptions {
 	agentOption := agent.AgentAddonOptions{
 		AddonName: t.name,
 		Registration: &agent.RegistrationOption{
-			CSRConfigurations: func(cluster *clusterv1.ManagedCluster) ([]addonapiv1alpha1.RegistrationConfig, error) {
+			CSRConfigurations: func(cluster *clusterv1.ManagedCluster, addon *addonapiv1alpha1.ManagedClusterAddOn) ([]addonapiv1alpha1.RegistrationConfig, error) {
 				return t.registrations, nil
 			},
 			PermissionConfig: func(cluster *clusterv1.ManagedCluster, addon *addonapiv1alpha1.ManagedClusterAddOn) error {

--- a/pkg/agent/inteface.go
+++ b/pkg/agent/inteface.go
@@ -98,11 +98,15 @@ type AgentAddonOptions struct {
 	ConfigCheckEnabled bool
 }
 
+type CSRConfigurationsFunc func(cluster *clusterv1.ManagedCluster) ([]addonapiv1alpha1.RegistrationConfig, error)
+
 type CSRSignerFunc func(cluster *clusterv1.ManagedCluster, addon *addonapiv1alpha1.ManagedClusterAddOn, csr *certificatesv1.CertificateSigningRequest) ([]byte, error)
 
 type CSRApproveFunc func(cluster *clusterv1.ManagedCluster, addon *addonapiv1alpha1.ManagedClusterAddOn, csr *certificatesv1.CertificateSigningRequest) bool
 
 type PermissionConfigFunc func(cluster *clusterv1.ManagedCluster, addon *addonapiv1alpha1.ManagedClusterAddOn) error
+
+type AgentInstallNamespaceFunc func(addon *addonapiv1alpha1.ManagedClusterAddOn) (string, error)
 
 // RegistrationOption defines how agent is registered to the hub cluster. It needs to define:
 // 1. csr with what subject/signer should be created
@@ -113,7 +117,7 @@ type RegistrationOption struct {
 	// CSRConfigurations returns a list of csr configuration for the adddon agent in a managed cluster.
 	// A csr will be created from the managed cluster for addon agent with each CSRConfiguration.
 	// +required
-	CSRConfigurations func(cluster *clusterv1.ManagedCluster) []addonapiv1alpha1.RegistrationConfig
+	CSRConfigurations CSRConfigurationsFunc
 
 	// Namespace is the namespace where registraiton credential will be put on the managed cluster. It
 	// will be overridden by installNamespace on ManagedClusterAddon spec if set
@@ -125,7 +129,7 @@ type RegistrationOption struct {
 	// Note: Set this very carefully. If this is set, the addon agent must be deployed in the same namespace, which
 	// means when implementing Manifests function in AgentAddon interface, the namespace of the addon agent manifest
 	// must be set to the same value returned by this function.
-	AgentInstallNamespace func(addon *addonapiv1alpha1.ManagedClusterAddOn) (string, error)
+	AgentInstallNamespace AgentInstallNamespaceFunc
 
 	// CSRApproveCheck checks whether the addon agent registration should be approved by the hub.
 	// Addon hub controller can implement this func to auto-approve all the CSRs. A better CSR check is
@@ -231,8 +235,8 @@ const (
 	HealthProberTypeWorkloadAvailability HealthProberType = "WorkloadAvailability"
 )
 
-func KubeClientSignerConfigurations(addonName, agentName string) func(cluster *clusterv1.ManagedCluster) []addonapiv1alpha1.RegistrationConfig {
-	return func(cluster *clusterv1.ManagedCluster) []addonapiv1alpha1.RegistrationConfig {
+func KubeClientSignerConfigurations(addonName, agentName string) CSRConfigurationsFunc {
+	return func(cluster *clusterv1.ManagedCluster) ([]addonapiv1alpha1.RegistrationConfig, error) {
 		return []addonapiv1alpha1.RegistrationConfig{
 			{
 				SignerName: certificatesv1.KubeAPIServerClientSignerName,
@@ -241,7 +245,7 @@ func KubeClientSignerConfigurations(addonName, agentName string) func(cluster *c
 					Groups: DefaultGroups(cluster.Name, addonName),
 				},
 			},
-		}
+		}, nil
 	}
 }
 

--- a/pkg/agent/inteface.go
+++ b/pkg/agent/inteface.go
@@ -98,11 +98,14 @@ type AgentAddonOptions struct {
 	ConfigCheckEnabled bool
 }
 
-type CSRConfigurationsFunc func(cluster *clusterv1.ManagedCluster) ([]addonapiv1alpha1.RegistrationConfig, error)
+type CSRConfigurationsFunc func(cluster *clusterv1.ManagedCluster,
+	addon *addonapiv1alpha1.ManagedClusterAddOn) ([]addonapiv1alpha1.RegistrationConfig, error)
 
-type CSRSignerFunc func(cluster *clusterv1.ManagedCluster, addon *addonapiv1alpha1.ManagedClusterAddOn, csr *certificatesv1.CertificateSigningRequest) ([]byte, error)
+type CSRSignerFunc func(cluster *clusterv1.ManagedCluster,
+	addon *addonapiv1alpha1.ManagedClusterAddOn, csr *certificatesv1.CertificateSigningRequest) ([]byte, error)
 
-type CSRApproveFunc func(cluster *clusterv1.ManagedCluster, addon *addonapiv1alpha1.ManagedClusterAddOn, csr *certificatesv1.CertificateSigningRequest) bool
+type CSRApproveFunc func(cluster *clusterv1.ManagedCluster,
+	addon *addonapiv1alpha1.ManagedClusterAddOn, csr *certificatesv1.CertificateSigningRequest) bool
 
 type PermissionConfigFunc func(cluster *clusterv1.ManagedCluster, addon *addonapiv1alpha1.ManagedClusterAddOn) error
 
@@ -236,7 +239,8 @@ const (
 )
 
 func KubeClientSignerConfigurations(addonName, agentName string) CSRConfigurationsFunc {
-	return func(cluster *clusterv1.ManagedCluster) ([]addonapiv1alpha1.RegistrationConfig, error) {
+	return func(cluster *clusterv1.ManagedCluster,
+		addon *addonapiv1alpha1.ManagedClusterAddOn) ([]addonapiv1alpha1.RegistrationConfig, error) {
 		return []addonapiv1alpha1.RegistrationConfig{
 			{
 				SignerName: certificatesv1.KubeAPIServerClientSignerName,

--- a/pkg/agent/inteface.go
+++ b/pkg/agent/inteface.go
@@ -98,7 +98,7 @@ type AgentAddonOptions struct {
 	ConfigCheckEnabled bool
 }
 
-type CSRSignerFunc func(csr *certificatesv1.CertificateSigningRequest) []byte
+type CSRSignerFunc func(cluster *clusterv1.ManagedCluster, addon *addonapiv1alpha1.ManagedClusterAddOn, csr *certificatesv1.CertificateSigningRequest) ([]byte, error)
 
 type CSRApproveFunc func(cluster *clusterv1.ManagedCluster, addon *addonapiv1alpha1.ManagedClusterAddOn, csr *certificatesv1.CertificateSigningRequest) bool
 

--- a/pkg/utils/csr_helper_test.go
+++ b/pkg/utils/csr_helper_test.go
@@ -64,7 +64,10 @@ func TestDefaultSigner(t *testing.T) {
 
 	signer := DefaultSignerWithExpiry(key, ca, 24*time.Hour)
 
-	cert := signer(newCSR("test", "cluster1"))
+	cert, err := signer(nil, nil, newCSR("test", "cluster1"))
+	if err != nil {
+		t.Errorf("Failed to sign the csr, %v", err)
+	}
 	if cert == nil {
 		t.Errorf("Expect cert to be signed")
 	}

--- a/pkg/utils/csr_helpers.go
+++ b/pkg/utils/csr_helpers.go
@@ -30,38 +30,34 @@ var serialNumberLimit = new(big.Int).Lsh(big.NewInt(1), 128)
 
 // DefaultSignerWithExpiry generates a signer func for addon agent to sign the csr using caKey and caData with expiry date.
 func DefaultSignerWithExpiry(caKey, caData []byte, duration time.Duration) agent.CSRSignerFunc {
-	return func(csr *certificatesv1.CertificateSigningRequest) []byte {
+	return func(cluster *clusterv1.ManagedCluster, addon *addonapiv1alpha1.ManagedClusterAddOn,
+		csr *certificatesv1.CertificateSigningRequest) ([]byte, error) {
 		blockTlsCrt, _ := pem.Decode(caData)
 		if blockTlsCrt == nil {
-			klog.Errorf("Failed to decode cert")
-			return nil
+			return nil, fmt.Errorf("failed to decode cert")
 		}
 		certs, err := x509.ParseCertificates(blockTlsCrt.Bytes)
 		if err != nil {
-			klog.Errorf("Failed to parse cert: %v", err)
-			return nil
+			return nil, fmt.Errorf("failed to parse cert: %v", err)
 		}
 
 		blockTlsKey, _ := pem.Decode(caKey)
 		if blockTlsKey == nil {
-			klog.Errorf("Failed to decode key")
-			return nil
+			return nil, fmt.Errorf("failed to decode key")
 		}
 
 		// For now only PKCS#1 is supported which assures the private key algorithm is RSA.
 		// TODO: Compatibility w/ PKCS#8 key e.g. EC algorithm
 		key, err := x509.ParsePKCS1PrivateKey(blockTlsKey.Bytes)
 		if err != nil {
-			klog.Errorf("Failed to parse key: %v", err)
-			return nil
+			return nil, fmt.Errorf("failed to parse key: %v", err)
 		}
 
 		data, err := signCSR(csr, certs[0], key, duration)
 		if err != nil {
-			klog.Errorf("Failed to sign csr: %v", err)
-			return nil
+			return nil, fmt.Errorf("failed to sign csr: %v", err)
 		}
-		return data
+		return data, nil
 	}
 }
 

--- a/test/integration/cloudevents/suite_test.go
+++ b/test/integration/cloudevents/suite_test.go
@@ -3,12 +3,13 @@ package cloudevents
 import (
 	"context"
 	"fmt"
-	"open-cluster-management.io/sdk-go/pkg/cloudevents/clients/options"
 	"os"
 	"path"
 	"path/filepath"
 	"testing"
 	"time"
+
+	"open-cluster-management.io/sdk-go/pkg/cloudevents/clients/options"
 
 	mochimqtt "github.com/mochi-mqtt/server/v2"
 	"github.com/mochi-mqtt/server/v2/hooks/auth"
@@ -237,8 +238,9 @@ func (t *testAddon) GetAgentAddonOptions() agent.AgentAddonOptions {
 			CSRApproveCheck: func(cluster *clusterv1.ManagedCluster, addon *addonapiv1alpha1.ManagedClusterAddOn, csr *certificatesv1.CertificateSigningRequest) bool {
 				return t.approveCSR
 			},
-			CSRSign: func(csr *certificatesv1.CertificateSigningRequest) []byte {
-				return t.cert
+			CSRSign: func(cluster *clusterv1.ManagedCluster, addon *addonapiv1alpha1.ManagedClusterAddOn,
+				csr *certificatesv1.CertificateSigningRequest) ([]byte, error) {
+				return t.cert, nil
 			},
 		}
 	}

--- a/test/integration/cloudevents/suite_test.go
+++ b/test/integration/cloudevents/suite_test.go
@@ -232,7 +232,7 @@ func (t *testAddon) GetAgentAddonOptions() agent.AgentAddonOptions {
 
 	if len(t.registrations) > 0 {
 		option.Registration = &agent.RegistrationOption{
-			CSRConfigurations: func(cluster *clusterv1.ManagedCluster) ([]addonapiv1alpha1.RegistrationConfig, error) {
+			CSRConfigurations: func(cluster *clusterv1.ManagedCluster, addon *addonapiv1alpha1.ManagedClusterAddOn) ([]addonapiv1alpha1.RegistrationConfig, error) {
 				return t.registrations[cluster.Name], nil
 			},
 			CSRApproveCheck: func(cluster *clusterv1.ManagedCluster, addon *addonapiv1alpha1.ManagedClusterAddOn, csr *certificatesv1.CertificateSigningRequest) bool {

--- a/test/integration/cloudevents/suite_test.go
+++ b/test/integration/cloudevents/suite_test.go
@@ -232,8 +232,8 @@ func (t *testAddon) GetAgentAddonOptions() agent.AgentAddonOptions {
 
 	if len(t.registrations) > 0 {
 		option.Registration = &agent.RegistrationOption{
-			CSRConfigurations: func(cluster *clusterv1.ManagedCluster) []addonapiv1alpha1.RegistrationConfig {
-				return t.registrations[cluster.Name]
+			CSRConfigurations: func(cluster *clusterv1.ManagedCluster) ([]addonapiv1alpha1.RegistrationConfig, error) {
+				return t.registrations[cluster.Name], nil
 			},
 			CSRApproveCheck: func(cluster *clusterv1.ManagedCluster, addon *addonapiv1alpha1.ManagedClusterAddOn, csr *certificatesv1.CertificateSigningRequest) bool {
 				return t.approveCSR

--- a/test/integration/kube/suite_test.go
+++ b/test/integration/kube/suite_test.go
@@ -165,8 +165,8 @@ func (t *testAddon) GetAgentAddonOptions() agent.AgentAddonOptions {
 
 	if len(t.registrations) > 0 {
 		option.Registration = &agent.RegistrationOption{
-			CSRConfigurations: func(cluster *clusterv1.ManagedCluster) []addonapiv1alpha1.RegistrationConfig {
-				return t.registrations[cluster.Name]
+			CSRConfigurations: func(cluster *clusterv1.ManagedCluster) ([]addonapiv1alpha1.RegistrationConfig, error) {
+				return t.registrations[cluster.Name], nil
 			},
 			CSRApproveCheck: func(cluster *clusterv1.ManagedCluster, addon *addonapiv1alpha1.ManagedClusterAddOn, csr *certificatesv1.CertificateSigningRequest) bool {
 				return t.approveCSR

--- a/test/integration/kube/suite_test.go
+++ b/test/integration/kube/suite_test.go
@@ -165,7 +165,8 @@ func (t *testAddon) GetAgentAddonOptions() agent.AgentAddonOptions {
 
 	if len(t.registrations) > 0 {
 		option.Registration = &agent.RegistrationOption{
-			CSRConfigurations: func(cluster *clusterv1.ManagedCluster) ([]addonapiv1alpha1.RegistrationConfig, error) {
+			CSRConfigurations: func(cluster *clusterv1.ManagedCluster,
+				addon *addonapiv1alpha1.ManagedClusterAddOn) ([]addonapiv1alpha1.RegistrationConfig, error) {
 				return t.registrations[cluster.Name], nil
 			},
 			CSRApproveCheck: func(cluster *clusterv1.ManagedCluster, addon *addonapiv1alpha1.ManagedClusterAddOn, csr *certificatesv1.CertificateSigningRequest) bool {

--- a/test/integration/kube/suite_test.go
+++ b/test/integration/kube/suite_test.go
@@ -171,8 +171,9 @@ func (t *testAddon) GetAgentAddonOptions() agent.AgentAddonOptions {
 			CSRApproveCheck: func(cluster *clusterv1.ManagedCluster, addon *addonapiv1alpha1.ManagedClusterAddOn, csr *certificatesv1.CertificateSigningRequest) bool {
 				return t.approveCSR
 			},
-			CSRSign: func(csr *certificatesv1.CertificateSigningRequest) []byte {
-				return t.cert
+			CSRSign: func(cluster *clusterv1.ManagedCluster, addon *addonapiv1alpha1.ManagedClusterAddOn,
+				csr *certificatesv1.CertificateSigningRequest) ([]byte, error) {
+				return t.cert, nil
 			},
 		}
 	}


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:rocket: 🚀 release
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

  - Updates CSRSign interface to include cluster and addon context parameters with error return
  - Enhances CSRConfigurations interface to accept addon parameter and return errors
  - Improves error handling and messaging throughout CSR processing

  ### Why do we need this
  **The template-type addons need to read the CSR configurations and signing information from the AddonTemplate. Currently, it finds the template from the ClusterManagementAddon, which is not 100% accurate, as the addontemplate could be overridden in the ManagedClusterAddon config. So with this change, we can find the accurate AddonTemplate from the managedclusteraddon status.**

  Fix [this TODO](https://github.com/open-cluster-management-io/ocm/blob/b506d16cf8c6f908183d987a05af95727c9ce9ce/pkg/addon/templateagent/registration.go#L236) in ocm

  ### Changes
  #### CSRSign Interface
  - **Before:** `CSRSign(csr *CertificateSigningRequest) []byte`
  - **After:** `CSRSign(cluster *ManagedCluster, addon *ManagedClusterAddOn, csr *CertificateSigningRequest) ([]byte, error)`

  #### CSRConfigurations Interface
  - **Before:** `CSRConfigurations(cluster *ManagedCluster) []RegistrationConfig`
  - **After:** `CSRConfigurations(cluster *ManagedCluster, addon *ManagedClusterAddOn) ([]RegistrationConfig, error)`

  ### Migration Guide
  **CSRSign implementations:**
  1. Add cluster and addon parameters (can be ignored if not needed)
  2. Return ([]byte, error) instead of just []byte
  3. Handle errors properly in your signing logic

  **CSRConfigurations implementations:**
  1. Accept both cluster and addon parameters
  2. Return ([]RegistrationConfig, error) instead of just []RegistrationConfig
  3. Use addon parameter for addon-specific configuration logic when needed
  4. Return appropriate errors when configuration generation fails

## Related issue(s)

https://github.com/open-cluster-management-io/ocm/issues/1179

Fixes #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Certificate signing now receives cluster and addon context and reports errors for safer, context-aware issuance.
  * Registration configuration callbacks now accept addon context and return errors.
  * Agent install namespace callback now returns a value and error.

* **Refactor**
  * Standardized callbacks to return (result, error) for clearer error propagation across signing and registration flows.

* **Tests**
  * Unit and integration tests updated to the new callback shapes and to validate error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->