### PR TITLE
🐛 Support empty AgentInstallNamespace for template-type addons

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	k8s.io/component-base v0.33.3
 	k8s.io/klog/v2 v2.130.1
 	k8s.io/utils v0.0.0-20241210054802-24370beab758
-	open-cluster-management.io/api v1.0.1-0.20251009064814-48b723491429
+	open-cluster-management.io/api v1.0.1-0.20251016015403-f042545132a3
 	open-cluster-management.io/sdk-go v1.0.1-0.20250811075710-18b20e146feb
 	sigs.k8s.io/controller-runtime v0.20.2
 )

--- a/go.sum
+++ b/go.sum
@@ -448,8 +448,8 @@ k8s.io/kube-openapi v0.0.0-20250318190949-c8a335a9a2ff h1:/usPimJzUKKu+m+TE36gUy
 k8s.io/kube-openapi v0.0.0-20250318190949-c8a335a9a2ff/go.mod h1:5jIi+8yX4RIb8wk3XwBo5Pq2ccx4FP10ohkbSKCZoK8=
 k8s.io/utils v0.0.0-20241210054802-24370beab758 h1:sdbE21q2nlQtFh65saZY+rRM6x6aJJI8IUa1AmH/qa0=
 k8s.io/utils v0.0.0-20241210054802-24370beab758/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
-open-cluster-management.io/api v1.0.1-0.20251009064814-48b723491429 h1:jU4r3zijNA+Ab17oF7lBck0YHc7f7wM8r2RqZJw6ZSs=
-open-cluster-management.io/api v1.0.1-0.20251009064814-48b723491429/go.mod h1:lEc5Wkc9ON5ym/qAtIqNgrE7NW7IEOCOC611iQMlnKM=
+open-cluster-management.io/api v1.0.1-0.20251016015403-f042545132a3 h1:PXT0zdNZ4T+3GwCjlY/0Xt5O2hxuEcBgRDvuxtkUy7c=
+open-cluster-management.io/api v1.0.1-0.20251016015403-f042545132a3/go.mod h1:lEc5Wkc9ON5ym/qAtIqNgrE7NW7IEOCOC611iQMlnKM=
 open-cluster-management.io/sdk-go v1.0.1-0.20250811075710-18b20e146feb h1:voE6JR6Xi8wNTSkhADHP19FpGICUpqt1/lEREQt7TVU=
 open-cluster-management.io/sdk-go v1.0.1-0.20250811075710-18b20e146feb/go.mod h1:sHOVhUgA286ceEq3IjFWqxobt9Lu+VBCAUZByFgN0oM=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.2 h1:jpcvIRr3GLoUoEKRkHKSmGjxb6lWwrBlJsXc+eUYQHM=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1426,7 +1426,7 @@ k8s.io/utils/path
 k8s.io/utils/pointer
 k8s.io/utils/ptr
 k8s.io/utils/trace
-# open-cluster-management.io/api v1.0.1-0.20251009064814-48b723491429
+# open-cluster-management.io/api v1.0.1-0.20251016015403-f042545132a3
 ## explicit; go 1.24.0
 open-cluster-management.io/api/addon/v1alpha1
 open-cluster-management.io/api/client/addon/clientset/versioned

--- a/vendor/open-cluster-management.io/api/addon/v1alpha1/0000_02_addon.open-cluster-management.io_addondeploymentconfigs.crd.yaml
+++ b/vendor/open-cluster-management.io/api/addon/v1alpha1/0000_02_addon.open-cluster-management.io_addondeploymentconfigs.crd.yaml
@@ -41,10 +41,12 @@ spec:
             properties:
               agentInstallNamespace:
                 default: open-cluster-management-agent-addon
-                description: AgentInstallNamespace is the namespace where the add-on
-                  agent should be installed on the managed cluster.
+                description: |-
+                  AgentInstallNamespace is the namespace where the add-on agent should be installed on the managed cluster.
+                  For template-type addons: set to empty string "" to use the namespace defined in the addonTemplate.
+                  For non-template addons: defaults to "open-cluster-management-agent-addon" if not specified.
                 maxLength: 63
-                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$
                 type: string
               customizedVariables:
                 description: |-

--- a/vendor/open-cluster-management.io/api/addon/v1alpha1/types_addondeploymentconfig.go
+++ b/vendor/open-cluster-management.io/api/addon/v1alpha1/types_addondeploymentconfig.go
@@ -54,10 +54,12 @@ type AddOnDeploymentConfigSpec struct {
 	ProxyConfig ProxyConfig `json:"proxyConfig,omitempty"`
 
 	// AgentInstallNamespace is the namespace where the add-on agent should be installed on the managed cluster.
+	// For template-type addons: set to empty string "" to use the namespace defined in the addonTemplate.
+	// For non-template addons: defaults to "open-cluster-management-agent-addon" if not specified.
 	// +optional
 	// +kubebuilder:default=open-cluster-management-agent-addon
 	// +kubebuilder:validation:MaxLength=63
-	// +kubebuilder:validation:Pattern=^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+	// +kubebuilder:validation:Pattern=^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$
 	AgentInstallNamespace string `json:"agentInstallNamespace,omitempty"`
 
 	// ResourceRequirements specify the resources required by add-on agents.

--- a/vendor/open-cluster-management.io/api/work/v1/types.go
+++ b/vendor/open-cluster-management.io/api/work/v1/types.go
@@ -517,6 +517,12 @@ const (
 	// WorkManifestsComplete represents that all completable manifests in the work
 	// have the Complete condition
 	WorkManifestsComplete string = "ManifestsComplete"
+	// WorkProgressingReasonApplying indicates resources are being applied
+	WorkProgressingReasonApplying string = "Applying"
+	// WorkProgressingReasonCompleted indicates all resources are applied and available
+	WorkProgressingReasonCompleted string = "Completed"
+	// WorkProgressingReasonFailed indicates the work failed to apply
+	WorkProgressingReasonFailed string = "Failed"
 )
 
 // ManifestCondition represents the conditions of the resources deployed on a

--- a/vendor/open-cluster-management.io/api/work/v1alpha1/0000_00_work.open-cluster-management.io_manifestworkreplicasets.crd.yaml
+++ b/vendor/open-cluster-management.io/api/work/v1alpha1/0000_00_work.open-cluster-management.io_manifestworkreplicasets.crd.yaml
@@ -741,7 +741,7 @@ spec:
                       description: Summary totals of resulting ManifestWorks for the
                         placement
                       properties:
-                        Applied:
+                        applied:
                           description: 'Applied is the number of ManifestWorks with
                             condition Applied: true'
                           type: integer
@@ -763,7 +763,7 @@ spec:
               summary:
                 description: Summary totals of resulting ManifestWorks for all placements
                 properties:
-                  Applied:
+                  applied:
                     description: 'Applied is the number of ManifestWorks with condition
                       Applied: true'
                     type: integer

--- a/vendor/open-cluster-management.io/api/work/v1alpha1/types_manifestworkreplicaset.go
+++ b/vendor/open-cluster-management.io/api/work/v1alpha1/types_manifestworkreplicaset.go
@@ -132,7 +132,7 @@ type ManifestWorkReplicaSetSummary struct {
 	// TODO: Degraded is the number of ManifestWorks with condition Degraded: true
 	Degraded int `json:"degraded"`
 	// Applied is the number of ManifestWorks with condition Applied: true
-	Applied int `json:"Applied"`
+	Applied int `json:"applied"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object


### PR DESCRIPTION
## Description

This PR adds support for template-type addons to use the namespace defined in their template manifest by setting `agentInstallNamespace: ""` in the AddonDeploymentConfig.

## Changes

### 1. API Upgrade
- Updated `open-cluster-management.io/api` to include https://github.com/open-cluster-management-io/api/pull/400
- This allows empty string for `AgentInstallNamespace` field

### 2. New Function
Added `AgentInstallNamespaceFromDeploymentConfigRawFunc` that:
- Returns the raw `AgentInstallNamespace` value including empty strings
- Enables template-type addons to signal "use template namespace" with `agentInstallNamespace: ""`
- Will be used by template-type addon controllers in the OCM repo

### 3. Backward Compatibility
Updated existing `AgentInstallNamespaceFromDeploymentConfigFunc` to:
- Explicitly return `"open-cluster-management-agent-addon"` when `AgentInstallNamespace` is empty
- Ensures existing addons continue to work without any changes
- Added documentation clarifying the behavior difference

### 4. Tests
- Added test for empty `AgentInstallNamespace` returning default namespace
- Added comprehensive tests for the new raw function
- All existing tests continue to pass

## Related Issues

https://github.com/open-cluster-management-io/ocm/issues/1209

## Testing

All unit tests pass:
\`\`\`
go test ./pkg/utils/... -v -run TestAgentInstallNamespace
\`\`\`

## Backward Compatibility

✅ This change is fully backward compatible. Existing addons using `AgentInstallNamespaceFromDeploymentConfigFunc` will continue to receive the default namespace when `AgentInstallNamespace` is empty or unset.

Template-type addons that want the new behavior should migrate to use `AgentInstallNamespaceFromDeploymentConfigRawFunc`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced addon deployment namespace configuration handling with improved backward compatibility. When namespace configuration is empty, the system now defaults to standard namespace instead of failing.

* **Chores**
  * Updated dependencies for improved stability.

* **Tests**
  * Added comprehensive test coverage for addon namespace configuration scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->