### PR TITLE
🐛 Fix health check to support partial probe results with multi-probe configuration

### DIFF
--- a/test/integration/kube/agent_deploy_test.go
+++ b/test/integration/kube/agent_deploy_test.go
@@ -922,8 +922,8 @@ var _ = ginkgo.Describe("Agent deploy", func() {
 				return err
 			}
 
-			// the daemonset is not probed, so the addon available condition is unknown
-			if !meta.IsStatusConditionPresentAndEqual(addon.Status.Conditions, "Available", metav1.ConditionUnknown) {
+			// the daemonset is not probed, so the addon available condition is false
+			if !meta.IsStatusConditionPresentAndEqual(addon.Status.Conditions, "Available", metav1.ConditionFalse) {
 				return fmt.Errorf("Unexpected addon available condition, %v", addon.Status.Conditions)
 			}
 			return nil


### PR DESCRIPTION
## Summary

This PR fixes issue #341 where the health check incorrectly marks addons as Unknown when using multiple health check probes and the first probe returns empty feedback results.

**Problem:**
When multiple health check ProbeFields are configured (e.g., checking both deployment and OLM), if the first probe returns empty feedback results, the code immediately returns and sets the addon status to Unknown. This prevents the evaluation of subsequent probes that may have valid results.

**Solution:**
- Modified the logic to collect all empty probe fields instead of returning immediately
- Only mark the addon as Unknown if ALL probes have no results
- Allow partial probe results to be considered valid (if at least one probe returns results)
- Removed redundant check for non-empty results in healthChecker path

**Changes:**
1. Added `emptyProbeFields` slice to track probes with no results
2. Changed early return to `continue` when a probe has no results
3. Added check after the loop to determine if all probes are empty
4. Improved error messaging to differentiate between single vs multiple empty probes
5. Added comprehensive test case for the multi-probe scenario

## Related issue(s)

Fixes #341

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Health checks now aggregate results from multiple probes before deciding availability, avoiding immediate "unknown" reports and allowing partial probe success to mark an add-on available.
  * Consolidated empty-probe handling into a single post-check status update with a clearer message.

* **Tests**
  * Added a test validating multi-probe aggregation when initial probes are empty but later probes succeed.

* **Integration**
  * Updated integration expectation: unprobeable add-ons now treated as unavailable (False) instead of Unknown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->