### PR TITLE
🌱 Add default namespace support to AgentInstallNamespaceFromDeploymentConfigFunc

### DIFF
--- a/pkg/utils/addon_config.go
+++ b/pkg/utils/addon_config.go
@@ -35,7 +35,7 @@ func (g *defaultAddOnDeploymentConfigGetter) Get(
 // namespace from the addon deployment config. If the addon does not support addon deployment config or there is no
 // matched addon deployment config, it will return an empty string.
 func AgentInstallNamespaceFromDeploymentConfigFunc(
-	adcgetter AddOnDeploymentConfigGetter,
+	adcgetter AddOnDeploymentConfigGetter, defaultNs ...string,
 ) func(*addonapiv1alpha1.ManagedClusterAddOn) (string, error) {
 	return func(addon *addonapiv1alpha1.ManagedClusterAddOn) (string, error) {
 		if addon == nil {
@@ -58,6 +58,9 @@ func AgentInstallNamespaceFromDeploymentConfigFunc(
 			return "", nil
 		}
 
+		if config.Spec.AgentInstallNamespace == "" && len(defaultNs) > 0 {
+			return defaultNs[0], nil
+		}
 		return config.Spec.AgentInstallNamespace, nil
 	}
 }


### PR DESCRIPTION
## Summary

This enhancement adds optional default namespace support to `AgentInstallNamespaceFromDeploymentConfigFunc`. When the addon deployment config doesn't specify an `AgentInstallNamespace`, callers can now provide a fallback default namespace.

## Changes

- Updated `AgentInstallNamespaceFromDeploymentConfigFunc` signature to accept optional `defaultNs ...string` parameter
- Added logic to return the default namespace when `config.Spec.AgentInstallNamespace` is empty and a default is provided

## Test plan

- [ ] Verify function works with no default namespace (existing behavior)
- [ ] Verify function returns default namespace when config's AgentInstallNamespace is empty
- [ ] Verify function still respects config's AgentInstallNamespace when set

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for optional default namespace fallback in addon deployment configuration. If the deployment config lacks a namespace specification, the provided default will be used.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->