### PR TITLE
🌱 Upgrade Go version to 1.25

### DIFF
--- a/.github/workflows/go-postsubmit.yml
+++ b/.github/workflows/go-postsubmit.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   # Common versions
-  GO_VERSION: '1.24'
+  GO_VERSION: '1.25'
   GO_REQUIRED_MIN_VERSION: ''
   GOPATH: '/home/runner/work/addon-framework/addon-framework/go'
 defaults:

--- a/.github/workflows/go-presubmit.yml
+++ b/.github/workflows/go-presubmit.yml
@@ -9,7 +9,7 @@ on:
 
 env:
   # Common versions
-  GO_VERSION: '1.24'
+  GO_VERSION: '1.25'
   GO_REQUIRED_MIN_VERSION: ''
 
 jobs:

--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -6,7 +6,7 @@ on:
       - 'v*.*.*'
 env:
   # Common versions
-  GO_VERSION: '1.24'
+  GO_VERSION: '1.25'
   GO_REQUIRED_MIN_VERSION: ''
   GITHUB_REF: ${{ github.ref }}
 

--- a/build/Dockerfile.example
+++ b/build/Dockerfile.example
@@ -1,4 +1,4 @@
-FROM golang:1.24-bullseye AS builder
+FROM golang:1.25-bullseye AS builder
 WORKDIR /go/src/open-cluster-management.io/addon-framework
 COPY . .
 ENV GO_PACKAGE open-cluster-management.io/addon-framework

--- a/build/Dockerfile.example
+++ b/build/Dockerfile.example
@@ -1,4 +1,4 @@
-FROM golang:1.25-bullseye AS builder
+FROM golang:1.25-bookworm AS builder
 WORKDIR /go/src/open-cluster-management.io/addon-framework
 COPY . .
 ENV GO_PACKAGE open-cluster-management.io/addon-framework

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module open-cluster-management.io/addon-framework
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/evanphx/json-patch/v5 v5.9.11


### PR DESCRIPTION
## Summary
- Updated Go version from 1.24 to 1.25 in go.mod
- Updated Go version in GitHub workflow files (go-presubmit.yml, go-postsubmit.yml, go-release.yml)
- Updated Go version in build/Dockerfile.example

## Test plan
- [ ] Verify that all workflows pass with Go 1.25
- [ ] Verify that the build succeeds
- [ ] Verify that all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)