### PR TITLE
🌱 Add image override utilities for managed cluster annotations

### DIFF
--- a/pkg/utils/image.go
+++ b/pkg/utils/image.go
@@ -1,0 +1,68 @@
+package utils
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"k8s.io/klog/v2"
+	addonapiv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
+	clusterv1 "open-cluster-management.io/api/cluster/v1"
+)
+
+// OverrideImageByAnnotation is to override the image by image-registries annotation of managedCluster.
+// The source registry will be replaced by the Mirror.
+// The larger index will work if the Sources are the same.
+func OverrideImageByAnnotation(annotations map[string]string, imageName string) (string, error) {
+	if len(annotations) == 0 {
+		return imageName, nil
+	}
+
+	if _, ok := annotations[clusterv1.ClusterImageRegistriesAnnotationKey]; !ok {
+		return imageName, nil
+	}
+
+	type ImageRegistries struct {
+		Registries []addonapiv1alpha1.ImageMirror `json:"registries"`
+	}
+
+	imageRegistries := ImageRegistries{}
+	err := json.Unmarshal([]byte(annotations[clusterv1.ClusterImageRegistriesAnnotationKey]), &imageRegistries)
+	if err != nil {
+		klog.Errorf("failed to unmarshal the annotation %v,err %v", annotations[clusterv1.ClusterImageRegistriesAnnotationKey], err)
+		return imageName, err
+	}
+
+	if len(imageRegistries.Registries) == 0 {
+		return imageName, nil
+	}
+	overrideImageName := imageName
+	for i := 0; i < len(imageRegistries.Registries); i++ {
+		registry := imageRegistries.Registries[i]
+		name := imageOverride(registry.Source, registry.Mirror, imageName)
+		if name != imageName {
+			overrideImageName = name
+		}
+	}
+	return overrideImageName, nil
+}
+
+func imageOverride(source, mirror, imageName string) string {
+	source = strings.TrimSuffix(source, "/")
+	mirror = strings.TrimSuffix(mirror, "/")
+	imageSegments := strings.Split(imageName, "/")
+	imageNameTag := imageSegments[len(imageSegments)-1]
+	if source == "" {
+		if mirror == "" {
+			return imageNameTag
+		}
+		return fmt.Sprintf("%s/%s", mirror, imageNameTag)
+	}
+
+	if !strings.HasPrefix(imageName, source) {
+		return imageName
+	}
+
+	trimSegment := strings.TrimPrefix(imageName, source)
+	return fmt.Sprintf("%s%s", mirror, trimSegment)
+}

--- a/pkg/utils/image_test.go
+++ b/pkg/utils/image_test.go
@@ -1,0 +1,243 @@
+package utils
+
+import (
+	"encoding/json"
+	"testing"
+
+	addonapiv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
+	clusterv1 "open-cluster-management.io/api/cluster/v1"
+)
+
+// newImageRegistriesAnnotation creates a JSON annotation string for image registries
+func newImageRegistriesAnnotation(registries []addonapiv1alpha1.ImageMirror) string {
+	type ImageRegistries struct {
+		Registries []addonapiv1alpha1.ImageMirror `json:"registries"`
+	}
+	data, _ := json.Marshal(ImageRegistries{Registries: registries})
+	return string(data)
+}
+
+func TestOverrideImageByAnnotation(t *testing.T) {
+	cases := []struct {
+		name        string
+		annotations map[string]string
+		imageName   string
+		expected    string
+		expectError bool
+	}{
+		{
+			name:        "nil annotations",
+			annotations: nil,
+			imageName:   "docker.io/library/nginx:latest",
+			expected:    "docker.io/library/nginx:latest",
+			expectError: false,
+		},
+		{
+			name:        "empty annotations",
+			annotations: map[string]string{},
+			imageName:   "docker.io/library/nginx:latest",
+			expected:    "docker.io/library/nginx:latest",
+			expectError: false,
+		},
+		{
+			name: "no image-registries key",
+			annotations: map[string]string{
+				"other-key": "other-value",
+			},
+			imageName:   "docker.io/library/nginx:latest",
+			expected:    "docker.io/library/nginx:latest",
+			expectError: false,
+		},
+		{
+			name: "invalid JSON annotation",
+			annotations: map[string]string{
+				clusterv1.ClusterImageRegistriesAnnotationKey: "invalid-json",
+			},
+			imageName:   "docker.io/library/nginx:latest",
+			expected:    "docker.io/library/nginx:latest",
+			expectError: true,
+		},
+		{
+			name: "empty registries array",
+			annotations: map[string]string{
+				clusterv1.ClusterImageRegistriesAnnotationKey: `{"registries":[]}`,
+			},
+			imageName:   "docker.io/library/nginx:latest",
+			expected:    "docker.io/library/nginx:latest",
+			expectError: false,
+		},
+		{
+			name: "single registry with match",
+			annotations: map[string]string{
+				clusterv1.ClusterImageRegistriesAnnotationKey: newImageRegistriesAnnotation([]addonapiv1alpha1.ImageMirror{
+					{Source: "docker.io/library", Mirror: "quay.io/library"},
+				}),
+			},
+			imageName:   "docker.io/library/nginx:latest",
+			expected:    "quay.io/library/nginx:latest",
+			expectError: false,
+		},
+		{
+			name: "single registry no match",
+			annotations: map[string]string{
+				clusterv1.ClusterImageRegistriesAnnotationKey: newImageRegistriesAnnotation([]addonapiv1alpha1.ImageMirror{
+					{Source: "docker.io/library", Mirror: "quay.io/library"},
+				}),
+			},
+			imageName:   "gcr.io/project/image:tag",
+			expected:    "gcr.io/project/image:tag",
+			expectError: false,
+		},
+		{
+			name: "multiple registries with different sources",
+			annotations: map[string]string{
+				clusterv1.ClusterImageRegistriesAnnotationKey: newImageRegistriesAnnotation([]addonapiv1alpha1.ImageMirror{
+					{Source: "docker.io/library", Mirror: "quay.io/library"},
+					{Source: "gcr.io/project", Mirror: "quay.io/project"},
+				}),
+			},
+			imageName:   "gcr.io/project/myapp:latest",
+			expected:    "quay.io/project/myapp:latest",
+			expectError: false,
+		},
+		{
+			name: "multiple registries latter wins when both match",
+			annotations: map[string]string{
+				clusterv1.ClusterImageRegistriesAnnotationKey: newImageRegistriesAnnotation([]addonapiv1alpha1.ImageMirror{
+					{Source: "docker.io/library", Mirror: "quay.io/library"},
+					{Source: "docker.io/library/nginx:latest", Mirror: "private.registry.io/nginx:v2"},
+				}),
+			},
+			imageName:   "docker.io/library/nginx:latest",
+			expected:    "private.registry.io/nginx:v2",
+			expectError: false,
+		},
+		{
+			name: "empty source acts as wildcard",
+			annotations: map[string]string{
+				clusterv1.ClusterImageRegistriesAnnotationKey: newImageRegistriesAnnotation([]addonapiv1alpha1.ImageMirror{
+					{Source: "", Mirror: "private.registry.io/mirror"},
+				}),
+			},
+			imageName:   "docker.io/library/nginx:latest",
+			expected:    "private.registry.io/mirror/nginx:latest",
+			expectError: false,
+		},
+		{
+			name: "trailing slashes trimmed",
+			annotations: map[string]string{
+				clusterv1.ClusterImageRegistriesAnnotationKey: newImageRegistriesAnnotation([]addonapiv1alpha1.ImageMirror{
+					{Source: "docker.io/library/", Mirror: "quay.io/library/"},
+				}),
+			},
+			imageName:   "docker.io/library/nginx:latest",
+			expected:    "quay.io/library/nginx:latest",
+			expectError: false,
+		},
+		{
+			name: "image with SHA digest",
+			annotations: map[string]string{
+				clusterv1.ClusterImageRegistriesAnnotationKey: newImageRegistriesAnnotation([]addonapiv1alpha1.ImageMirror{
+					{Source: "docker.io/library", Mirror: "quay.io/library"},
+				}),
+			},
+			imageName:   "docker.io/library/nginx@sha256:abc123def456",
+			expected:    "quay.io/library/nginx@sha256:abc123def456",
+			expectError: false,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			result, err := OverrideImageByAnnotation(c.annotations, c.imageName)
+			if c.expectError {
+				if err == nil {
+					t.Errorf("expected error but got nil")
+				}
+			} else {
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+			}
+			if result != c.expected {
+				t.Errorf("expected %s but got %s", c.expected, result)
+			}
+		})
+	}
+}
+
+func TestImageOverride(t *testing.T) {
+	cases := []struct {
+		name      string
+		source    string
+		mirror    string
+		imageName string
+		expected  string
+	}{
+		{
+			name:      "both source and mirror empty",
+			source:    "",
+			mirror:    "",
+			imageName: "docker.io/namespace/image:tag",
+			expected:  "image:tag",
+		},
+		{
+			name:      "source empty mirror provided",
+			source:    "",
+			mirror:    "quay.io/namespace",
+			imageName: "docker.io/namespace/image:tag",
+			expected:  "quay.io/namespace/image:tag",
+		},
+		{
+			name:      "source provided no match",
+			source:    "docker.io",
+			mirror:    "quay.io",
+			imageName: "gcr.io/namespace/image:tag",
+			expected:  "gcr.io/namespace/image:tag",
+		},
+		{
+			name:      "source provided with match",
+			source:    "docker.io/namespace",
+			mirror:    "quay.io/namespace",
+			imageName: "docker.io/namespace/image:tag",
+			expected:  "quay.io/namespace/image:tag",
+		},
+		{
+			name:      "trailing slashes trimmed",
+			source:    "docker.io/namespace/",
+			mirror:    "quay.io/namespace/",
+			imageName: "docker.io/namespace/image:tag",
+			expected:  "quay.io/namespace/image:tag",
+		},
+		{
+			name:      "source with partial path match",
+			source:    "docker.io/project",
+			mirror:    "quay.io/project",
+			imageName: "docker.io/project/sub/image:tag",
+			expected:  "quay.io/project/sub/image:tag",
+		},
+		{
+			name:      "image with sha digest",
+			source:    "docker.io/library",
+			mirror:    "quay.io/library",
+			imageName: "docker.io/library/nginx@sha256:abc123def456",
+			expected:  "quay.io/library/nginx@sha256:abc123def456",
+		},
+		{
+			name:      "simple image name only",
+			source:    "",
+			mirror:    "quay.io",
+			imageName: "nginx:latest",
+			expected:  "quay.io/nginx:latest",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			result := imageOverride(c.source, c.mirror, c.imageName)
+			if result != c.expected {
+				t.Errorf("expected %s but got %s", c.expected, result)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Add `OverrideImageByAnnotation` function to override container images based on managed cluster's image-registries annotation
- Add `imageOverride` helper function for source-to-mirror registry replacement
- Include comprehensive unit tests covering edge cases

## Features
- Support multiple registry mappings with priority (latter entries override earlier ones)
- Handle empty source as wildcard to override all images
- Normalize trailing slashes in registry URLs
- Support both tag and SHA digest image references

## Test plan
- [x] Run `go test -v ./pkg/utils/... -run "Test.*Image"` - all 20 test cases pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)