### PR TITLE
:seedling: Add cluster and CSR name to approval logs

### DIFF
--- a/pkg/utils/csr_helpers.go
+++ b/pkg/utils/csr_helpers.go
@@ -178,11 +178,11 @@ func DefaultCSRApprover(agentName string) agent.CSRApproveFunc {
 		}
 
 		if strings.HasPrefix(username, "system:open-cluster-management:"+cluster.Name) {
-			klog.Info("CSR approved")
+			klog.Infof("CSR %q approved for cluster %q", csr.Name, cluster.Name)
 			return true
 		}
 
-		klog.Info("CSR not approved due to illegal requester", "requester", csr.Spec.Username)
+		klog.Infof("CSR %q for cluster %q not approved due to illegal requester %q", csr.Name, cluster.Name, csr.Spec.Username)
 		return false
 	}
 }


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:rocket: 🚀 release
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

Hello, this is my first PR here, happy to start contributing with a small one 😄 .

Updated the DefaultCSRApprover in `pkg/utils/csr_helpers.go` to include the Managed Cluster name and the CSR name in the log messages when a CSR is approved or denied.

This improves traceability and facilitate performance analysis in large-scale environments.

## Related issue(s)

Fixes #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved logging for Certificate Signing Request operations: approval and rejection messages are now more descriptive, including CSR name, cluster identifier, and requester username, and are emitted at the informational log level.
  * No changes to approval decision logic or public interfaces; this is a logging-only update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->