### PR TITLE
🐛 [WORK IN-PROGRESS] Allow user to provide custom certs on default path

### DIFF
--- a/pkg/cmd/factory/factory.go
+++ b/pkg/cmd/factory/factory.go
@@ -267,19 +267,65 @@ func toServerConfig() (*genericapiserver.Config, error) {
 
 	servingOptions := genericapiserveroptions.NewSecureServingOptions()
 	servingOptions.BindPort = 8443
-	temporaryCertDir, err := os.MkdirTemp("", "serving-cert")
-	if err != nil {
-		return nil, err
+
+	certPath := "/var/run/secrets/serving-cert/tls.crt"
+	keyPath := "/var/run/secrets/serving-cert/tls.key"
+
+	_, certErr := os.Stat(certPath)
+	_, keyErr := os.Stat(keyPath)
+	certsExist := certErr == nil && keyErr == nil
+
+	if certsExist {
+		servingOptions.ServerCert.CertKey.CertFile = certPath
+		servingOptions.ServerCert.CertKey.KeyFile = keyPath
+	} else {
+		// Non-FIPS fallback
+		tempDir, err := os.MkdirTemp("", "serving-cert")
+		if err != nil {
+			return nil, fmt.Errorf("failed to create temp cert directory: %w", err)
+		}
+		servingOptions.ServerCert.CertDirectory = tempDir
+		servingOptions.ServerCert.PairName = "tls"
 	}
-	servingOptions.ServerCert.CertDirectory = temporaryCertDir
-	servingOptions.ServerCert.PairName = "tls"
+
+	// This is safe if certsExist is true
 	if err := servingOptions.MaybeDefaultWithSelfSignedCerts("localhost", nil, []net.IP{net.ParseIP("127.0.0.1")}); err != nil {
 		return nil, err
 	}
 
-	servingOptionsWithLoopback := servingOptions.WithLoopback()
+	// --- THE BYPASS STRATEGY ---
+	if certsExist {
+		// 1. Manually apply Secure Serving (the server part)
+		if err := servingOptions.ApplyTo(&config.SecureServing); err != nil {
+			return nil, err
+		}
 
-	if err := servingOptionsWithLoopback.ApplyTo(&config.SecureServing, &config.LoopbackClientConfig); err != nil {
+		// 2. Manually construct the Loopback Client (the client part)
+		// This bypasses ApplyTo()'s internal GenerateSelfSignedCertKey logic entirely
+		certData, err := os.ReadFile(certPath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read serving cert: %w", err)
+		}
+		keyData, err := os.ReadFile(keyPath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read serving key: %w", err)
+		}
+
+		config.LoopbackClientConfig = &rest.Config{
+			Host: config.SecureServing.Listener.Addr().String(),
+			TLSClientConfig: rest.TLSClientConfig{
+				CAData:   certData,
+				CertData: certData,
+				KeyData:  keyData,
+			},
+		}
+
+		// We are done. Return early so we don't hit servingOptionsWithLoopback.ApplyTo()
+		return config, nil
+	}
+
+	// --- FALLBACK FOR NON-FIPS (original logic) ---
+	if err := servingOptions.WithLoopback().ApplyTo(&config.SecureServing, &config.LoopbackClientConfig); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:rocket: 🚀 release
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
We are using the addon framework and found that the default certs getting generated are crypto/SHA1 which does follow FIPS rule

With this PR - We are providing mechanism to provide the custom certs by the user on default path 
```
	certPath := "/var/run/secrets/serving-cert/tls.crt"
	keyPath := "/var/run/secrets/serving-cert/tls.key"
```
If found these file will be used certs provided 
else, Use the default work flow


Tested with the FIPS and non FIPS cluster using the  **"fips140=only"**
Working as expected 

## Related issue(s)

Fixes #
https://github.com/open-cluster-management-io/addon-framework/issues/362


Test reults:
```
•STEP: tearing down the test environment
I0218 15:04:02.883557   73549 base_controller.go:112] "Shutting down ..." logger="addon-deploy-controller"
I0218 15:04:02.883553   73549 base_controller.go:112] "Shutting down ..." logger="CSRApprovingController"
I0218 15:04:02.883603   73549 base_controller.go:87] "Shutting down worker of controller ..." logger="CSRApprovingController"
I0218 15:04:02.883607   73549 base_controller.go:112] "Shutting down ..." logger="CSRSignController"
I0218 15:04:02.883625   73549 base_controller.go:112] "Shutting down ..." logger="addon-registration-controller"
I0218 15:04:02.883630   73549 base_controller.go:87] "Shutting down worker of controller ..." logger="CSRSignController"
I0218 15:04:02.883645   73549 base_controller.go:87] "Shutting down worker of controller ..." logger="addon-deploy-controller"
I0218 15:04:02.883626   73549 base_controller.go:77] "All workers have been terminated" logger="CSRApprovingController"
I0218 15:04:02.883652   73549 base_controller.go:87] "Shutting down worker of controller ..." logger="addon-registration-controller"
I0218 15:04:02.883664   73549 base_controller.go:112] "Shutting down ..." logger="cma-managed-by-controller"
I0218 15:04:02.883689   73549 base_controller.go:77] "All workers have been terminated" logger="addon-registration-controller"
I0218 15:04:02.883669   73549 base_controller.go:77] "All workers have been terminated" logger="addon-deploy-controller"
I0218 15:04:02.883698   73549 base_controller.go:77] "All workers have been terminated" logger="CSRSignController"
I0218 15:04:02.883692   73549 base_controller.go:87] "Shutting down worker of controller ..." logger="cma-managed-by-controller"
I0218 15:04:02.883906   73549 base_controller.go:77] "All workers have been terminated" logger="cma-managed-by-controller"

Ran 20 of 20 Specs in 130.040 seconds
SUCCESS! -- 20 Passed | 0 Failed | 0 Pending | 0 Skipped

You're using deprecated Ginkgo functionality:
=============================================
Ginkgo 2.0 is under active development and will introduce several new features, improvements, and a small handful of breaking changes.
A release candidate for 2.0 is now available and 2.0 should GA in Fall 2021.  Please give the RC a try and send us feedback!
  - To learn more, view the migration guide at https://github.com/onsi/ginkgo/blob/ver2/docs/MIGRATING_TO_V2.md
  - For instructions on using the Release Candidate visit https://github.com/onsi/ginkgo/blob/ver2/docs/MIGRATING_TO_V2.md#using-the-beta
  - To comment, chime in at https://github.com/onsi/ginkgo/issues/711

  You are passing a Done channel to a test node to test asynchronous behavior.  This is deprecated in Ginkgo V2.  Your test will run synchronously and the timeout will be ignored.
  Learn more at: https://github.com/onsi/ginkgo/blob/ver2/docs/MIGRATING_TO_V2.md#removed-async-testing
    /Users/kk/workspace/addon-framework/test/integration/kube/suite_test.go:57

To silence deprecations that can be silenced set the following environment variable:
  ACK_GINKGO_DEPRECATIONS=1.16.5

PASS
[results.log](https://github.com/user-attachments/files/25387767/results.log)

```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for using supplied server certificates: when valid cert/key are present, the server uses them instead of generating temporary ones.

* **Behavior/Improvement**
  * Improved startup handling: when supplied certificates are detected, the server applies secure settings directly and skips redundant certificate generation.

* **Fallback**
  * Maintains existing automatic self-signed certificate generation when no certificates are provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->