### PR TITLE
:bug: CheckAddonPodFunc: require pod readiness in addition to running phase

### DIFF
--- a/pkg/lease/lease_controller.go
+++ b/pkg/lease/lease_controller.go
@@ -128,7 +128,10 @@ func (r *leaseUpdater) reconcile(ctx context.Context) {
 	}
 }
 
-// CheckAddonPodFunc checks whether the agent pod is running
+// CheckAddonPodFunc checks whether the agent pod is running and ready.
+// A pod must be both in the Running phase and have the Ready condition set to True
+// to be considered healthy. This prevents the lease from being updated when the pod
+// is running but not yet ready to serve (e.g., readiness probe is failing).
 func CheckAddonPodFunc(podGetter corev1client.PodsGetter, namespace, labelSelector string) func() bool {
 	return func() bool {
 		pods, err := podGetter.Pods(namespace).List(context.TODO(), metav1.ListOptions{LabelSelector: labelSelector})
@@ -137,16 +140,25 @@ func CheckAddonPodFunc(podGetter corev1client.PodsGetter, namespace, labelSelect
 			return false
 		}
 
-		// If one of the pods is running, we think the agent is serving.
-		for _, pod := range pods.Items {
-			if pod.Status.Phase == corev1.PodRunning {
+		// If one of the pods is running and ready, we think the agent is serving.
+		for i := range pods.Items {
+			if pods.Items[i].Status.Phase == corev1.PodRunning && isPodReady(&pods.Items[i]) {
 				return true
 			}
 		}
 
 		return false
 	}
+}
 
+// isPodReady checks whether a pod has the Ready condition set to True.
+func isPodReady(pod *corev1.Pod) bool {
+	for _, cond := range pod.Status.Conditions {
+		if cond.Type == corev1.PodReady {
+			return cond.Status == corev1.ConditionTrue
+		}
+	}
+	return false
 }
 
 // CheckManagedClusterHealthFunc checks the health status of the cluster api server

--- a/pkg/lease/lease_controller_test.go
+++ b/pkg/lease/lease_controller_test.go
@@ -140,12 +140,27 @@ func TestCheckAddonPodFunc(t *testing.T) {
 			expected: false,
 		},
 		{
-			name: "running state",
+			name: "running but not ready",
+			pods: []runtime.Object{
+				&corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{Name: "pod-1", Namespace: "test", Labels: map[string]string{"addon": "test"}},
+					Status:     corev1.PodStatus{Phase: corev1.PodRunning},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "running and ready",
 			pods: []runtime.Object{
 				&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod-1", Namespace: "test", Labels: map[string]string{"addon": "test"}}},
 				&corev1.Pod{
 					ObjectMeta: metav1.ObjectMeta{Name: "pod-2", Namespace: "test", Labels: map[string]string{"addon": "test"}},
-					Status:     corev1.PodStatus{Phase: corev1.PodRunning},
+					Status: corev1.PodStatus{
+						Phase: corev1.PodRunning,
+						Conditions: []corev1.PodCondition{
+							{Type: corev1.PodReady, Status: corev1.ConditionTrue},
+						},
+					},
 				},
 			},
 			expected: true,


### PR DESCRIPTION
## Summary

- `CheckAddonPodFunc` now checks both pod **Running** phase and **Ready** condition before updating the addon lease
- Previously, a pod could be `Running` but not `Ready` (e.g., readiness probe failing), causing the lease to be updated and the hub to incorrectly consider the addon as healthy
- Added `isPodReady` helper function that checks the `PodReady` condition status

## Motivation

When an addon agent pod is in the `Running` phase but its readiness probe is failing, the pod is not truly ready to serve. However, the existing `CheckAddonPodFunc` only checked `pod.Status.Phase == PodRunning`, which would still allow the lease to be updated. This could lead to the hub cluster incorrectly reporting the addon as `Available` when it is not actually ready.

By requiring the pod to also have the `Ready` condition set to `True`, the lease update more accurately reflects the addon agent's actual health status.

## Changes

- **`pkg/lease/lease_controller.go`**: Modified `CheckAddonPodFunc` to also verify pod readiness via the `PodReady` condition. Added `isPodReady` helper function.
- **`pkg/lease/lease_controller_test.go`**: Updated test cases - the previous "running state" case (Running but no Ready condition) now correctly returns `false`. Added "running and ready" test case that verifies a pod with both Running phase and Ready condition returns `true`. Added "running but not ready" test case.

## Test plan

- [x] Unit tests pass (`go test ./pkg/lease/ -v`)
- [ ] Verify in a real cluster that addon lease is not updated when agent pod readiness probe is failing
- [ ] Verify addon status transitions to `Degraded`/`Unavailable` when agent pod becomes not-ready


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced addon pod health checks to verify pods are both running and fully ready, improving system stability and reliability.

* **Tests**
  * Updated test cases to validate stricter pod readiness requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->