### PR TITLE
:bug: addon fix for Install namespace potential race condition with addondeploymentconfig - For issue: https://github.com/open-cluster-management-io/ocm/issues/1465

### DIFF
--- a/pkg/utils/addon_config.go
+++ b/pkg/utils/addon_config.go
@@ -49,15 +49,6 @@ func AgentInstallNamespaceFromDeploymentConfigFunc(
 		}
 
 		if config == nil {
-			// If the addon declares support for addondeploymentconfigs but the Configured condition
-			// is not yet True, the addonconfiguration controller either hasn't processed this MCA
-			// or hasn't finished rolling out configs. In either case configReferences may be
-			// incomplete. Return an error to trigger a requeue rather than falling back to the
-			// default namespace, which would be wrong if a config with a custom namespace exists.
-			if addonSupportsDeploymentConfig(addon) && !addonConfiguredTrue(addon) {
-				return "", fmt.Errorf("addon %s supports addondeploymentconfigs but configuration has not been synced yet, need to retry.",
-					addon.Name)
-			}
 			klog.V(4).InfoS("Addon deployment config is nil, return an empty string for agent install namespace",
 				"addonNamespace", addon.Namespace, "addonName", addon.Name)
 			return "", nil
@@ -76,6 +67,14 @@ func GetDesiredAddOnDeploymentConfig(
 	ok, configRef := GetAddOnConfigRef(addon.Status.ConfigReferences,
 		AddOnDeploymentConfigGVR.Group, AddOnDeploymentConfigGVR.Resource)
 	if !ok {
+		// If the addon declares support for addondeploymentconfigs but the Configured condition
+		// is not yet True, the addonconfiguration controller either hasn't processed this MCA
+		// or hasn't finished rolling out configs. In either case configReferences may be
+		// incomplete. Return an error so callers retry rather than proceeding with no config.
+		if addonSupportsDeploymentConfig(addon) && !addonConfiguredTrue(addon) {
+			return nil, fmt.Errorf("addon %s supports addondeploymentconfigs but Configured condition is not True yet, need to retry",
+				addon.Name)
+		}
 		return nil, nil
 	}
 

--- a/pkg/utils/addon_config.go
+++ b/pkg/utils/addon_config.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -47,12 +48,16 @@ func AgentInstallNamespaceFromDeploymentConfigFunc(
 			return "", fmt.Errorf("failed to get deployment config for addon %s: %v", addon.Name, err)
 		}
 
-		// For now, we have no way of knowing if the addon depleoyment config is not configured, or
-		// is configured but not yet been added to the managedclusteraddon status config references,
-		// we expect no error will be returned when the addon deployment config is not configured
-		// so we can use the default namespace.
-		// TODO: Find a way to distinguish between the above two cases
 		if config == nil {
+			// If the addon declares support for addondeploymentconfigs but the Configured condition
+			// is not yet True, the addonconfiguration controller either hasn't processed this MCA
+			// or hasn't finished rolling out configs. In either case configReferences may be
+			// incomplete. Return an error to trigger a requeue rather than falling back to the
+			// default namespace, which would be wrong if a config with a custom namespace exists.
+			if addonSupportsDeploymentConfig(addon) && !addonConfiguredTrue(addon) {
+				return "", fmt.Errorf("addon %s supports addondeploymentconfigs but configuration has not been synced yet, need to retry.",
+					addon.Name)
+			}
 			klog.V(4).InfoS("Addon deployment config is nil, return an empty string for agent install namespace",
 				"addonNamespace", addon.Namespace, "addonName", addon.Name)
 			return "", nil
@@ -133,4 +138,18 @@ func GetAddOnConfigRef(
 	}
 
 	return false, addonapiv1beta1.ConfigReference{}
+}
+
+func addonSupportsDeploymentConfig(addon *addonapiv1beta1.ManagedClusterAddOn) bool {
+	for _, sc := range addon.Status.SupportedConfigs {
+		if sc.Group == AddOnDeploymentConfigGVR.Group && sc.Resource == AddOnDeploymentConfigGVR.Resource {
+			return true
+		}
+	}
+	return false
+}
+
+func addonConfiguredTrue(addon *addonapiv1beta1.ManagedClusterAddOn) bool {
+	cond := meta.FindStatusCondition(addon.Status.Conditions, addonapiv1beta1.ManagedClusterAddOnConditionConfigured)
+	return cond != nil && cond.Status == metav1.ConditionTrue
 }

--- a/pkg/utils/addon_config_test.go
+++ b/pkg/utils/addon_config_test.go
@@ -26,10 +26,11 @@ func newTestAddOnDeploymentConfigGetter(adc *addonapiv1beta1.AddOnDeploymentConf
 func TestAgentInstallNamespaceFromDeploymentConfigFunc(t *testing.T) {
 
 	cases := []struct {
-		name     string
-		getter   AddOnDeploymentConfigGetter
-		mca      *addonapiv1beta1.ManagedClusterAddOn
-		expected string
+		name        string
+		getter      AddOnDeploymentConfigGetter
+		mca         *addonapiv1beta1.ManagedClusterAddOn
+		expected    string
+		expectError bool
 	}{
 		{
 			name: "addon is nil",
@@ -40,8 +41,9 @@ func TestAgentInstallNamespaceFromDeploymentConfigFunc(t *testing.T) {
 					},
 					Spec: addonapiv1beta1.AddOnDeploymentConfigSpec{},
 				}),
-			mca:      nil,
-			expected: "",
+			mca:         nil,
+			expected:    "",
+			expectError: true,
 		},
 		{
 			name: "addon no deployment config reference",
@@ -93,7 +95,8 @@ func TestAgentInstallNamespaceFromDeploymentConfigFunc(t *testing.T) {
 					},
 				},
 			},
-			expected: "",
+			expected:    "",
+			expectError: true,
 		},
 		// {
 		// 	name: "addon deployment config reference spec hash not match",
@@ -165,13 +168,139 @@ func TestAgentInstallNamespaceFromDeploymentConfigFunc(t *testing.T) {
 			},
 			expected: "testns",
 		},
+		{
+			name: "addon supports deployment config but Configured condition absent - should requeue",
+			getter: newTestAddOnDeploymentConfigGetter(
+				&addonapiv1beta1.AddOnDeploymentConfig{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test1",
+					},
+					Spec: addonapiv1beta1.AddOnDeploymentConfigSpec{
+						AgentInstallNamespace: "custom-ns",
+					},
+				}),
+			mca: &addonapiv1beta1.ManagedClusterAddOn{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test1",
+					Namespace: "cluster1",
+				},
+				Status: addonapiv1beta1.ManagedClusterAddOnStatus{
+					SupportedConfigs: []addonapiv1beta1.ConfigGroupResource{
+						{
+							Group:    "addon.open-cluster-management.io",
+							Resource: "addondeploymentconfigs",
+						},
+					},
+					ConfigReferences: []addonapiv1beta1.ConfigReference{},
+				},
+			},
+			expected:    "",
+			expectError: true,
+		},
+		{
+			name: "addon supports deployment config but Configured condition is False - should requeue",
+			getter: newTestAddOnDeploymentConfigGetter(
+				&addonapiv1beta1.AddOnDeploymentConfig{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test1",
+					},
+					Spec: addonapiv1beta1.AddOnDeploymentConfigSpec{
+						AgentInstallNamespace: "custom-ns",
+					},
+				}),
+			mca: &addonapiv1beta1.ManagedClusterAddOn{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test1",
+					Namespace: "cluster1",
+				},
+				Status: addonapiv1beta1.ManagedClusterAddOnStatus{
+					SupportedConfigs: []addonapiv1beta1.ConfigGroupResource{
+						{
+							Group:    "addon.open-cluster-management.io",
+							Resource: "addondeploymentconfigs",
+						},
+					},
+					ConfigReferences: []addonapiv1beta1.ConfigReference{},
+					Conditions: []metav1.Condition{
+						{
+							Type:   addonapiv1beta1.ManagedClusterAddOnConditionConfigured,
+							Status: metav1.ConditionFalse,
+							Reason: "ConfigurationsNotConfigured",
+						},
+					},
+				},
+			},
+			expected:    "",
+			expectError: true,
+		},
+		{
+			name: "addon supports deployment config and Configured=True but no config exists - use default",
+			getter: newTestAddOnDeploymentConfigGetter(
+				&addonapiv1beta1.AddOnDeploymentConfig{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test1",
+					},
+					Spec: addonapiv1beta1.AddOnDeploymentConfigSpec{},
+				}),
+			mca: &addonapiv1beta1.ManagedClusterAddOn{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test1",
+					Namespace: "cluster1",
+				},
+				Status: addonapiv1beta1.ManagedClusterAddOnStatus{
+					SupportedConfigs: []addonapiv1beta1.ConfigGroupResource{
+						{
+							Group:    "addon.open-cluster-management.io",
+							Resource: "addondeploymentconfigs",
+						},
+					},
+					ConfigReferences: []addonapiv1beta1.ConfigReference{},
+					Conditions: []metav1.Condition{
+						{
+							Type:   addonapiv1beta1.ManagedClusterAddOnConditionConfigured,
+							Status: metav1.ConditionTrue,
+							Reason: "ConfigurationsConfigured",
+						},
+					},
+				},
+			},
+			expected:    "",
+			expectError: false,
+		},
+		{
+			name: "addon does not support deployment config and no config - use default",
+			getter: newTestAddOnDeploymentConfigGetter(
+				&addonapiv1beta1.AddOnDeploymentConfig{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test1",
+					},
+					Spec: addonapiv1beta1.AddOnDeploymentConfigSpec{},
+				}),
+			mca: &addonapiv1beta1.ManagedClusterAddOn{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test1",
+					Namespace: "cluster1",
+				},
+				Status: addonapiv1beta1.ManagedClusterAddOnStatus{
+					SupportedConfigs: []addonapiv1beta1.ConfigGroupResource{},
+					ConfigReferences: []addonapiv1beta1.ConfigReference{},
+				},
+			},
+			expected:    "",
+			expectError: false,
+		},
 	}
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			nsFunc := AgentInstallNamespaceFromDeploymentConfigFunc(c.getter)
-			ns, _ := nsFunc(context.TODO(), c.mca)
-			assert.Equal(t, c.expected, ns, "should be equal")
+			ns, err := nsFunc(context.TODO(), c.mca)
+			assert.Equal(t, c.expected, ns, "namespace should be equal")
+			if c.expectError {
+				assert.Error(t, err, "should return error")
+			} else {
+				assert.NoError(t, err, "should not return error")
+			}
 		})
 	}
 }

--- a/pkg/utils/addon_config_test.go
+++ b/pkg/utils/addon_config_test.go
@@ -304,3 +304,158 @@ func TestAgentInstallNamespaceFromDeploymentConfigFunc(t *testing.T) {
 		})
 	}
 }
+
+func TestGetDesiredAddOnDeploymentConfig(t *testing.T) {
+	cases := []struct {
+		name        string
+		getter      AddOnDeploymentConfigGetter
+		addon       *addonapiv1beta1.ManagedClusterAddOn
+		expectNil   bool
+		expectError bool
+	}{
+		{
+			name: "no config ref and addon does not support deployment config - return nil",
+			getter: newTestAddOnDeploymentConfigGetter(
+				&addonapiv1beta1.AddOnDeploymentConfig{}),
+			addon: &addonapiv1beta1.ManagedClusterAddOn{
+				ObjectMeta: metav1.ObjectMeta{Name: "test1", Namespace: "cluster1"},
+				Status: addonapiv1beta1.ManagedClusterAddOnStatus{
+					ConfigReferences: []addonapiv1beta1.ConfigReference{},
+				},
+			},
+			expectNil: true,
+		},
+		{
+			name: "no config ref, supports deployment config, Configured absent - error to retry",
+			getter: newTestAddOnDeploymentConfigGetter(
+				&addonapiv1beta1.AddOnDeploymentConfig{}),
+			addon: &addonapiv1beta1.ManagedClusterAddOn{
+				ObjectMeta: metav1.ObjectMeta{Name: "test1", Namespace: "cluster1"},
+				Status: addonapiv1beta1.ManagedClusterAddOnStatus{
+					SupportedConfigs: []addonapiv1beta1.ConfigGroupResource{
+						{Group: "addon.open-cluster-management.io", Resource: "addondeploymentconfigs"},
+					},
+					ConfigReferences: []addonapiv1beta1.ConfigReference{},
+				},
+			},
+			expectNil:   true,
+			expectError: true,
+		},
+		{
+			name: "no config ref, supports deployment config, Configured=False - error to retry",
+			getter: newTestAddOnDeploymentConfigGetter(
+				&addonapiv1beta1.AddOnDeploymentConfig{}),
+			addon: &addonapiv1beta1.ManagedClusterAddOn{
+				ObjectMeta: metav1.ObjectMeta{Name: "test1", Namespace: "cluster1"},
+				Status: addonapiv1beta1.ManagedClusterAddOnStatus{
+					SupportedConfigs: []addonapiv1beta1.ConfigGroupResource{
+						{Group: "addon.open-cluster-management.io", Resource: "addondeploymentconfigs"},
+					},
+					ConfigReferences: []addonapiv1beta1.ConfigReference{},
+					Conditions: []metav1.Condition{
+						{
+							Type:   addonapiv1beta1.ManagedClusterAddOnConditionConfigured,
+							Status: metav1.ConditionFalse,
+							Reason: "ConfigurationsNotConfigured",
+						},
+					},
+				},
+			},
+			expectNil:   true,
+			expectError: true,
+		},
+		{
+			name: "no config ref, supports deployment config, Configured=True - nil config is authoritative",
+			getter: newTestAddOnDeploymentConfigGetter(
+				&addonapiv1beta1.AddOnDeploymentConfig{}),
+			addon: &addonapiv1beta1.ManagedClusterAddOn{
+				ObjectMeta: metav1.ObjectMeta{Name: "test1", Namespace: "cluster1"},
+				Status: addonapiv1beta1.ManagedClusterAddOnStatus{
+					SupportedConfigs: []addonapiv1beta1.ConfigGroupResource{
+						{Group: "addon.open-cluster-management.io", Resource: "addondeploymentconfigs"},
+					},
+					ConfigReferences: []addonapiv1beta1.ConfigReference{},
+					Conditions: []metav1.Condition{
+						{
+							Type:   addonapiv1beta1.ManagedClusterAddOnConditionConfigured,
+							Status: metav1.ConditionTrue,
+							Reason: "ConfigurationsConfigured",
+						},
+					},
+				},
+			},
+			expectNil:   true,
+			expectError: false,
+		},
+		{
+			name: "config ref with valid spec hash - returns config",
+			getter: newTestAddOnDeploymentConfigGetter(
+				&addonapiv1beta1.AddOnDeploymentConfig{
+					ObjectMeta: metav1.ObjectMeta{Name: "test1"},
+					Spec: addonapiv1beta1.AddOnDeploymentConfigSpec{
+						AgentInstallNamespace: "custom-ns",
+					},
+				}),
+			addon: &addonapiv1beta1.ManagedClusterAddOn{
+				ObjectMeta: metav1.ObjectMeta{Name: "test1", Namespace: "cluster1"},
+				Status: addonapiv1beta1.ManagedClusterAddOnStatus{
+					ConfigReferences: []addonapiv1beta1.ConfigReference{
+						{
+							ConfigGroupResource: addonapiv1beta1.ConfigGroupResource{
+								Group:    "addon.open-cluster-management.io",
+								Resource: "addondeploymentconfigs",
+							},
+							DesiredConfig: &addonapiv1beta1.ConfigSpecHash{
+								ConfigReferent: addonapiv1beta1.ConfigReferent{Name: "test1"},
+								SpecHash:       "f97b3f6af1f786ec6f3273e2d6fc8717e45cb7bc9797ba7533663a7de84a5538",
+							},
+						},
+					},
+				},
+			},
+			expectNil:   false,
+			expectError: false,
+		},
+		{
+			name: "config ref with empty spec hash - error",
+			getter: newTestAddOnDeploymentConfigGetter(
+				&addonapiv1beta1.AddOnDeploymentConfig{
+					ObjectMeta: metav1.ObjectMeta{Name: "test1"},
+				}),
+			addon: &addonapiv1beta1.ManagedClusterAddOn{
+				ObjectMeta: metav1.ObjectMeta{Name: "test1", Namespace: "cluster1"},
+				Status: addonapiv1beta1.ManagedClusterAddOnStatus{
+					ConfigReferences: []addonapiv1beta1.ConfigReference{
+						{
+							ConfigGroupResource: addonapiv1beta1.ConfigGroupResource{
+								Group:    "addon.open-cluster-management.io",
+								Resource: "addondeploymentconfigs",
+							},
+							DesiredConfig: &addonapiv1beta1.ConfigSpecHash{
+								ConfigReferent: addonapiv1beta1.ConfigReferent{Name: "test1"},
+							},
+						},
+					},
+				},
+			},
+			expectNil:   true,
+			expectError: true,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			config, err := GetDesiredAddOnDeploymentConfig(c.addon, c.getter)
+			if c.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+			if c.expectNil {
+				assert.Nil(t, config)
+			} else {
+				assert.NotNil(t, config)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:rocket: 🚀 release
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

Fixes a race condition where addon controllers use the default namespace (open-cluster-management-agent-addon) before AddonDeploymentConfig has been synced to MCA status by the  addonconfiguration controller.                                                                                                                                                        
                                                                                                                                                                                        
When the registration controller (addon-framework) reconciles an MCA before the addonconfiguration controller (OCM addon-manager) has written configReferences, GetDesiredAddOnDeploymentConfig returns nil, nil — meaning "no config exists." Callers fall back to the default namespace, which is wrong if an AddonDeploymentConfig with a custom   
  namespace is actually configured.                                                                                                                                                     
                                                                                                                                                                                        
The fix checks two signals in MCA status before accepting an empty configReferences as authoritative:                                                                                 
  - supportedConfigs — does the addon declare support for addondeploymentconfigs?                                                                                                       
  - Configured condition — has the addonconfiguration controller set it to True?                                                                                                        
                                                                                                                                                                    
If the addon supports deployment configs but Configured is not yet True, an error is returned so callers requeue instead of proceeding with stale data. The check is in  GetDesiredAddOnDeploymentConfig to protect all three callers: AgentInstallNamespaceFromDeploymentConfigFunc, GetAddOnDeploymentConfigValues, and GetAgentImageValues. 


Things to note:

- This does return a new error in the case where we determine that the addonconfiguration controller has not yet updated. The code was put into GetDesiredAddOnDeploymentConfig() instead of AgentInstallNamespaceFromDeploymentConfigFunc directly.  this means it does affect more callers as indicated above.
- To determine if the configReferences have not been populated yet, we are using the .status.Condition `Configured` and checking that it exists and is True.  This means potentially we keep reconciling until this happens. Is there any potential issue here? It seems the configurationcontroller updates the status.configReferences and adds the Configured condition at the same time.
- Additionally, this requires the caller to retry on error - this does generally happen here: https://github.com/open-cluster-management-io/addon-framework/blob/bbaaa1ea338e24bc03e24ffec46605d867277d56/pkg/addonmanager/controllers/registration/controller.go#L278-L281.   However other callers could choose to ignore I suppose.

## Related issue(s)

Fixes #

https://github.com/open-cluster-management-io/ocm/issues/1465

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved addon deployment configuration handling: the app now distinguishes missing configuration from unsupported addons, triggers retries when an addon supports deployment config but isn't yet configured, and continues gracefully for unsupported or already-configured cases.

* **Tests**
  * Added comprehensive tests covering supported/unsupported addon scenarios, missing or false configured conditions, and various config-reference states to validate retry and defaulting behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->