### PR TITLE
:seedling: chore: pin GitHub Actions to digest SHAs and replace setup-kind

### DIFF
--- a/.github/workflows/cloudevents-integration.yml
+++ b/.github/workflows/cloudevents-integration.yml
@@ -23,9 +23,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: install Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@be3c94b385c4f180051c996d336f57a34c397495 # v3
         with:
           go-version: ${{ env.GO_VERSION }}
       - name: integration

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -13,10 +13,10 @@ jobs:
     steps:
     - name: Get PR Commits
       id: 'get-pr-commits'
-      uses: tim-actions/get-pr-commits@master
+      uses: tim-actions/get-pr-commits@198af03565609bb4ed924d1260247b4881f09e7d # master
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
     - name: DCO Check
-      uses: tim-actions/dco@master
+      uses: tim-actions/dco@f2279e6e62d5a7d9115b0cb8e837b777b1b02e21 # master
       with:
         commits: ${{ steps.get-pr-commits.outputs.commits }}

--- a/.github/workflows/go-postsubmit.yml
+++ b/.github/workflows/go-postsubmit.yml
@@ -24,12 +24,12 @@ jobs:
         arch: [ amd64, arm64 ]
     steps:
       - name: checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 1
           path: go/src/open-cluster-management.io/addon-framework
       - name: install Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@be3c94b385c4f180051c996d336f57a34c397495 # v3
         with:
           go-version: ${{ env.GO_VERSION }}
       - name: install imagebuilder
@@ -51,7 +51,7 @@ jobs:
     needs: [ images ]
     steps:
       - name: checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 1
           path: go/src/open-cluster-management.io/addon-framework

--- a/.github/workflows/go-presubmit.yml
+++ b/.github/workflows/go-presubmit.yml
@@ -11,6 +11,7 @@ env:
   # Common versions
   GO_VERSION: '1.26'
   GO_REQUIRED_MIN_VERSION: ''
+  KUBERNETES_VERSION: 'v1.35.0'
 
 jobs:
   verify:
@@ -18,11 +19,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 1
       - name: install Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@be3c94b385c4f180051c996d336f57a34c397495 # v3
         with:
           go-version: ${{ env.GO_VERSION }}
       - name: verify
@@ -33,11 +34,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 1
       - name: install Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@be3c94b385c4f180051c996d336f57a34c397495 # v3
         with:
           go-version: ${{ env.GO_VERSION }}
       - name: verify-deps
@@ -48,11 +49,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 1
       - name: install Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@be3c94b385c4f180051c996d336f57a34c397495 # v3
         with:
           go-version: ${{ env.GO_VERSION }}
       - name: build
@@ -63,11 +64,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 1
       - name: install Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@be3c94b385c4f180051c996d336f57a34c397495 # v3
         with:
           go-version: ${{ env.GO_VERSION }}
       - name: unit
@@ -78,11 +79,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 1
       - name: install Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@be3c94b385c4f180051c996d336f57a34c397495 # v3
         with:
           go-version: ${{ env.GO_VERSION }}
       - name: integration
@@ -93,11 +94,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 1
       - name: install Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@be3c94b385c4f180051c996d336f57a34c397495 # v3
         with:
           go-version: ${{ env.GO_VERSION }}
       - name: install imagebuilder
@@ -105,10 +106,7 @@ jobs:
       - name: addon-examples-image # will build and tag the examples image
         run: imagebuilder --allow-pull -t quay.io/open-cluster-management/addon-examples:latest -t quay.io/ocm/addon-examples:latest -f ./build/Dockerfile.example .
       - name: setup kind
-        uses: engineerd/setup-kind@v0.6.2
-        with:
-          version: v0.31.0
-          name: cluster1
+        run: kind create cluster --name cluster1 --image kindest/node:${{ env.KUBERNETES_VERSION }} --wait 300s
       - name: Load image on the nodes of the cluster
         run: |
           kind load docker-image --name=cluster1 quay.io/open-cluster-management/addon-examples:latest
@@ -124,11 +122,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 1
       - name: install Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@be3c94b385c4f180051c996d336f57a34c397495 # v3
         with:
           go-version: ${{ env.GO_VERSION }}
       - name: install imagebuilder
@@ -136,10 +134,7 @@ jobs:
       - name: addon-examples-image # will build and tag the examples image
         run: imagebuilder --allow-pull -t quay.io/open-cluster-management/addon-examples:latest -t quay.io/ocm/addon-examples:latest -f ./build/Dockerfile.example .
       - name: setup kind
-        uses: engineerd/setup-kind@v0.6.2
-        with:
-          version: v0.31.0
-          name: cluster1
+        run: kind create cluster --name cluster1 --image kindest/node:${{ env.KUBERNETES_VERSION }} --wait 300s
       - name: Load image on the nodes of the cluster
         run: |
           kind load docker-image --name=cluster1 quay.io/open-cluster-management/addon-examples:latest
@@ -155,11 +150,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 1
       - name: install Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@be3c94b385c4f180051c996d336f57a34c397495 # v3
         with:
           go-version: ${{ env.GO_VERSION }}
       - name: install imagebuilder
@@ -167,10 +162,7 @@ jobs:
       - name: addon-examples-image # will build and tag the examples image
         run: imagebuilder --allow-pull -t quay.io/open-cluster-management/addon-examples:latest -t quay.io/ocm/addon-examples:latest -f ./build/Dockerfile.example .
       - name: setup kind
-        uses: engineerd/setup-kind@v0.6.2
-        with:
-          version: v0.31.0
-          name: cluster1
+        run: kind create cluster --name cluster1 --image kindest/node:${{ env.KUBERNETES_VERSION }} --wait 300s
       - name: Load image on the nodes of the cluster
         run: |
           kind load docker-image --name=cluster1 quay.io/open-cluster-management/addon-examples:latest
@@ -186,11 +178,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 1
       - name: install Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@be3c94b385c4f180051c996d336f57a34c397495 # v3
         with:
           go-version: ${{ env.GO_VERSION }}
       - name: install imagebuilder
@@ -198,10 +190,7 @@ jobs:
       - name: addon-examples-image # will build and tag the examples image
         run: imagebuilder --allow-pull -t quay.io/open-cluster-management/addon-examples:latest -t quay.io/ocm/addon-examples:latest -f ./build/Dockerfile.example .
       - name: setup kind
-        uses: engineerd/setup-kind@v0.6.2
-        with:
-          version: v0.31.0
-          name: cluster1
+        run: kind create cluster --name cluster1 --image kindest/node:${{ env.KUBERNETES_VERSION }} --wait 300s
       - name: Load image on the nodes of the cluster
         run: |
           kind load docker-image --name=cluster1 quay.io/open-cluster-management/addon-examples:latest
@@ -217,11 +206,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 1
       - name: install Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@be3c94b385c4f180051c996d336f57a34c397495 # v3
         with:
           go-version: ${{ env.GO_VERSION }}
       - name: install imagebuilder

--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 1
       - name: get release version
@@ -38,11 +38,11 @@ jobs:
         arch: [ amd64, arm64 ]
     steps:
       - name: checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 1
       - name: install Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@be3c94b385c4f180051c996d336f57a34c397495 # v3
         with:
           go-version: ${{ env.GO_VERSION }}
       - name: install imagebuilder
@@ -64,7 +64,7 @@ jobs:
     needs: [ env, images ]
     steps:
       - name: checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 1
       - name: create
@@ -88,14 +88,14 @@ jobs:
     needs: [ env, image-manifest ]
     steps:
       - name: checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 1
       - name: generate changelog
         run: |
           echo "# Addon Framework ${{ needs.env.outputs.RELEASE_VERSION }}" > /home/runner/work/changelog.txt
       - name: publish release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
Pin all GitHub Actions to immutable commit SHAs to prevent supply chain issues from moving tags.

Replace `engineerd/setup-kind` with a direct `kind create cluster` run step using the `kind` binary pre-installed on GitHub-hosted runners. The Kubernetes node image version is now explicit via `KUBERNETES_VERSION` env variable set to `v1.35.0` (same version previously used by kind v0.31.0 by default).

Removing setup-kind GH action as it appears to no longer be maintained, and now is causing issues when we use v0.6.2 as the tag v0.6.2 points to a version that is not correct (actual version is the branch v0.6.2). Note both are old and last modified in 2024.

~~> **Note:** Draft PR — to be merged after the Go 1.26 upgrade PR (#385) merges to avoid conflicts.~~