### PR TITLE
:bug: Fix GetAddOnConfigRef selection order

### DIFF
--- a/pkg/utils/addon_config.go
+++ b/pkg/utils/addon_config.go
@@ -120,18 +120,22 @@ func GetAddOnDeploymentConfigSpecHash(config *addonapiv1beta1.AddOnDeploymentCon
 	})
 }
 
-// GetAddOnConfigRef returns the first addon config ref for the given config type. It is fine since the status will only
-// have one config for each GK.
-// (TODO) this needs to be reconcidered if we support multiple same GK in the config referencese.
+// GetAddOnConfigRef returns the last addon config ref for the given config type.
+// When multiple config references share the same group+resource, the highest-index
+// entry takes precedence, consistent with the contract documented on
+// GetAddOnDeploymentConfigValues.
 func GetAddOnConfigRef(
 	configReferences []addonapiv1beta1.ConfigReference,
 	group, resource string) (bool, addonapiv1beta1.ConfigReference) {
 
+	found := false
+	var result addonapiv1beta1.ConfigReference
 	for _, config := range configReferences {
 		if config.Group == group && config.Resource == resource {
-			return true, config
+			found = true
+			result = config
 		}
 	}
 
-	return false, addonapiv1beta1.ConfigReference{}
+	return found, result
 }

--- a/pkg/utils/addon_config_test.go
+++ b/pkg/utils/addon_config_test.go
@@ -23,6 +23,136 @@ func newTestAddOnDeploymentConfigGetter(adc *addonapiv1beta1.AddOnDeploymentConf
 	return &testadcGetter{adc: adc}
 }
 
+func TestGetAddOnConfigRef(t *testing.T) {
+	cases := []struct {
+		name             string
+		configReferences []addonapiv1beta1.ConfigReference
+		group            string
+		resource         string
+		expectedFound    bool
+		expectedName     string
+	}{
+		{
+			name:             "no config references",
+			configReferences: []addonapiv1beta1.ConfigReference{},
+			group:            "addon.open-cluster-management.io",
+			resource:         "addondeploymentconfigs",
+			expectedFound:    false,
+			expectedName:     "",
+		},
+		{
+			name: "no matching group+resource",
+			configReferences: []addonapiv1beta1.ConfigReference{
+				{
+					ConfigGroupResource: addonapiv1beta1.ConfigGroupResource{
+						Group: "addon.open-cluster-management.io", Resource: "addontemplates",
+					},
+					DesiredConfig: &addonapiv1beta1.ConfigSpecHash{
+						ConfigReferent: addonapiv1beta1.ConfigReferent{Name: "my-template"},
+						SpecHash:       "hash1",
+					},
+				},
+			},
+			group:         "addon.open-cluster-management.io",
+			resource:      "addondeploymentconfigs",
+			expectedFound: false,
+			expectedName:  "",
+		},
+		{
+			name: "single match",
+			configReferences: []addonapiv1beta1.ConfigReference{
+				{
+					ConfigGroupResource: addonapiv1beta1.ConfigGroupResource{
+						Group: "addon.open-cluster-management.io", Resource: "addondeploymentconfigs",
+					},
+					DesiredConfig: &addonapiv1beta1.ConfigSpecHash{
+						ConfigReferent: addonapiv1beta1.ConfigReferent{Name: "only-one"},
+						SpecHash:       "hash1",
+					},
+				},
+			},
+			group:         "addon.open-cluster-management.io",
+			resource:      "addondeploymentconfigs",
+			expectedFound: true,
+			expectedName:  "only-one",
+		},
+		{
+			name: "multiple matches returns last",
+			configReferences: []addonapiv1beta1.ConfigReference{
+				{
+					ConfigGroupResource: addonapiv1beta1.ConfigGroupResource{
+						Group: "addon.open-cluster-management.io", Resource: "addondeploymentconfigs",
+					},
+					DesiredConfig: &addonapiv1beta1.ConfigSpecHash{
+						ConfigReferent: addonapiv1beta1.ConfigReferent{Name: "first-adc"},
+						SpecHash:       "hash1",
+					},
+				},
+				{
+					ConfigGroupResource: addonapiv1beta1.ConfigGroupResource{
+						Group: "addon.open-cluster-management.io", Resource: "addondeploymentconfigs",
+					},
+					DesiredConfig: &addonapiv1beta1.ConfigSpecHash{
+						ConfigReferent: addonapiv1beta1.ConfigReferent{Name: "second-adc"},
+						SpecHash:       "hash2",
+					},
+				},
+			},
+			group:         "addon.open-cluster-management.io",
+			resource:      "addondeploymentconfigs",
+			expectedFound: true,
+			expectedName:  "second-adc",
+		},
+		{
+			name: "multiple matches with interleaved types returns last of target type",
+			configReferences: []addonapiv1beta1.ConfigReference{
+				{
+					ConfigGroupResource: addonapiv1beta1.ConfigGroupResource{
+						Group: "addon.open-cluster-management.io", Resource: "addondeploymentconfigs",
+					},
+					DesiredConfig: &addonapiv1beta1.ConfigSpecHash{
+						ConfigReferent: addonapiv1beta1.ConfigReferent{Name: "global-defaults"},
+						SpecHash:       "hash1",
+					},
+				},
+				{
+					ConfigGroupResource: addonapiv1beta1.ConfigGroupResource{
+						Group: "addon.open-cluster-management.io", Resource: "addontemplates",
+					},
+					DesiredConfig: &addonapiv1beta1.ConfigSpecHash{
+						ConfigReferent: addonapiv1beta1.ConfigReferent{Name: "my-template"},
+						SpecHash:       "hash2",
+					},
+				},
+				{
+					ConfigGroupResource: addonapiv1beta1.ConfigGroupResource{
+						Group: "addon.open-cluster-management.io", Resource: "addondeploymentconfigs",
+					},
+					DesiredConfig: &addonapiv1beta1.ConfigSpecHash{
+						ConfigReferent: addonapiv1beta1.ConfigReferent{Name: "per-cluster-override"},
+						SpecHash:       "hash3",
+					},
+				},
+			},
+			group:         "addon.open-cluster-management.io",
+			resource:      "addondeploymentconfigs",
+			expectedFound: true,
+			expectedName:  "per-cluster-override",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			found, ref := GetAddOnConfigRef(c.configReferences, c.group, c.resource)
+			assert.Equal(t, c.expectedFound, found, "found mismatch")
+			if c.expectedFound {
+				assert.Equal(t, c.expectedName, ref.DesiredConfig.ConfigReferent.Name,
+					"should return the last matching config reference")
+			}
+		})
+	}
+}
+
 func TestAgentInstallNamespaceFromDeploymentConfigFunc(t *testing.T) {
 
 	cases := []struct {


### PR DESCRIPTION
## Summary
Corrects precedence of selection when there are multiple config references of the same group-kind. (Should be last in list instead of first.)

## Related issue(s)

Fixes https://github.com/open-cluster-management-io/addon-framework/issues/387


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * When multiple matching config references exist, the app now uses the latest matching entry instead of the first one.
  * Improved handling when no matching reference is found, returning a clear “not found” result.

* **Tests**
  * Added coverage for single, missing, mixed, and duplicate match scenarios to verify the updated selection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->