### PR TITLE
:bug: normalize Helm values before schema validation

### DIFF
--- a/docs/helmAgentAddon.md
+++ b/docs/helmAgentAddon.md
@@ -45,6 +45,8 @@ Helm Chart built-in values
 
 In the list of `GetValuesFuncs`, the values from the big index Func will override the one from low index Func.
 The built-in values will override the values got from the list of `GetValuesFuncs`.
+The values returned by `GetValuesFuncs` may contain typed Go values such as `map[string]string` or structs with json tags; they are normalized to JSON-compatible types before merging.
+Values that cannot be marshaled to JSON will make the manifest rendering fail.
 
 The Variable names in Values should begin with lowercase. So the best practice is to define a json struct for the values, and convert it to Values using the `JsonStructToValues`.
 
@@ -52,4 +54,3 @@ The Variable names in Values should begin with lowercase. So the best practice i
 We support a helper `GetValuesFunc` named `GetValuesFromAddonAnnotation` which can get values from annotation of ManagedClusterAddon.
 The key of the Helm Chart values in annotation is `addon.open-cluster-management.io/values`,
 and the value should be a valid json string which has key-value format.
-

--- a/pkg/addonfactory/helm_agentaddon.go
+++ b/pkg/addonfactory/helm_agentaddon.go
@@ -187,8 +187,15 @@ func (a *HelmAgentAddon) getValues(
 				return overrideValues, err
 			}
 
-			klog.V(4).Infof("index=%d, user values: %v", i, userValues)
-			overrideValues = MergeValues(overrideValues, userValues)
+			// MergeValues deep-merges only map[string]interface{} values, so typed Go
+			// maps and structs must be normalized to JSON-compatible types beforehand.
+			normalizedUserValues, err := JsonStructToValues(userValues)
+			if err != nil {
+				return overrideValues, fmt.Errorf("failed to normalize Helm values: %w", err)
+			}
+
+			klog.V(4).Infof("index=%d, user values: %v", i, normalizedUserValues)
+			overrideValues = MergeValues(overrideValues, normalizedUserValues)
 			klog.V(4).Infof("index=%d, override values: %v", i, overrideValues)
 		}
 	}

--- a/pkg/addonfactory/helm_agentaddon_test.go
+++ b/pkg/addonfactory/helm_agentaddon_test.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -81,6 +82,13 @@ func TestChartAgentAddon_Manifests(t *testing.T) {
 		},
 	}
 
+	customTolerations := []corev1.Toleration{{
+		Key:      "dedicated",
+		Operator: corev1.TolerationOpEqual,
+		Value:    "addon",
+		Effect:   corev1.TaintEffectNoSchedule,
+	}}
+
 	cases := []struct {
 		name                            string
 		scheme                          *runtime.Scheme
@@ -93,12 +101,14 @@ func TestChartAgentAddon_Manifests(t *testing.T) {
 		getValuesFunc                   GetValuesFunc
 		expectedInstallNamespace        string
 		expectedNodeSelector            map[string]string
+		expectedTolerations             []corev1.Toleration
 		expectedImage                   string
 		expectedObjCnt                  int
 		expectedHubKubeConfigSecret     string
 		expectedManagedKubeConfigSecret string
 		expectedNamespace               bool
 		expectedResourceRequirements    *corev1.ResourceRequirements
+		expectedError                   string
 	}{
 		{
 			name:                         "template render ok with annotation values",
@@ -161,6 +171,31 @@ func TestChartAgentAddon_Manifests(t *testing.T) {
 			expectedResourceRequirements:    &defaultResourceReqirements,
 		},
 		{
+			name:             "template render ok with concrete Go collection values and preserves merged values",
+			scheme:           testScheme,
+			clusterName:      "cluster1",
+			addonName:        "helloworld",
+			installNamespace: "myNs",
+			annotationValues: `{"global":{"nodeSelector":{"existing":"preserved"}}}`,
+			getValuesFunc: func(cluster *clusterv1.ManagedCluster, addon *addonapiv1beta1.ManagedClusterAddOn) (Values, error) {
+				return Values{
+					"global": map[string]interface{}{
+						"nodeSelector": map[string]string{"kubernetes.io/os": "linux"},
+					},
+					"tolerations": customTolerations,
+				}, nil
+			},
+			expectedInstallNamespace: "myNs",
+			expectedNodeSelector: map[string]string{
+				"existing":         "preserved",
+				"kubernetes.io/os": "linux",
+			},
+			expectedTolerations:          customTolerations,
+			expectedImage:                "quay.io/testimage:test",
+			expectedObjCnt:               4,
+			expectedResourceRequirements: &defaultResourceReqirements,
+		},
+		{
 			name:                         "template render ok, getting hosting cluster with client",
 			scheme:                       testScheme,
 			clusterName:                  "cluster1",
@@ -199,6 +234,17 @@ func TestChartAgentAddon_Manifests(t *testing.T) {
 			expectedObjCnt:               4,
 			expectedResourceRequirements: &customResourceReqirements,
 		},
+		{
+			name:             "template render failed with values unsupported by json",
+			scheme:           testScheme,
+			clusterName:      "cluster1",
+			addonName:        "helloworld",
+			installNamespace: "myNs",
+			getValuesFunc: func(cluster *clusterv1.ManagedCluster, addon *addonapiv1beta1.ManagedClusterAddOn) (Values, error) {
+				return Values{"unsupported": make(chan string)}, nil
+			},
+			expectedError: "failed to normalize Helm values: json: unsupported type: chan string",
+		},
 	}
 
 	for _, c := range cases {
@@ -234,6 +280,10 @@ func TestChartAgentAddon_Manifests(t *testing.T) {
 				t.Errorf("expected no error, got err %v", err)
 			}
 			objects, err := agentAddon.Manifests(context.TODO(), cluster, clusterAddon)
+			if len(c.expectedError) > 0 {
+				assert.ErrorContains(t, err, c.expectedError)
+				return
+			}
 			if err != nil {
 				t.Errorf("expected no error, got err %v", err)
 			}
@@ -253,6 +303,9 @@ func TestChartAgentAddon_Manifests(t *testing.T) {
 						if nodeSelector[k] != v {
 							t.Errorf("expected nodeSelector is %v, but got %v", c.expectedNodeSelector, nodeSelector)
 						}
+					}
+					if c.expectedTolerations != nil {
+						assert.Equal(t, c.expectedTolerations, object.Spec.Template.Spec.Tolerations, "expected tolerations to match")
 					}
 
 					if object.Spec.Template.Spec.Containers[0].Image != c.expectedImage {

--- a/pkg/addonfactory/testmanifests/chart/values.schema.json
+++ b/pkg/addonfactory/testmanifests/chart/values.schema.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "$comment": "exercises helm schema validation; typed Go values that are not normalized to JSON-compatible types fail this validation",
+  "type": "object",
+  "properties": {
+    "tolerations": {
+      "type": "array"
+    }
+  }
+}


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:rocket: 🚀 release
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

Helm schema validation rejects concrete Go collections returned by `GetValuesFuncs` with `invalid jsonType`, forcing each add-on to merge and normalize values itself; normalize the merged values in addon-framework instead.

## Related issue(s)

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Helm value handling by normalizing user-provided values into JSON-compatible forms before merging, fixing rendering for settings such as pod tolerations.
  * Better failure behavior and clearer error messages when Helm values contain unsupported data types.
* **Documentation**
  * Clarified that returned Helm values may be typed and are normalized to JSON-compatible types prior to validation/rendering.
* **Tests**
  * Expanded coverage for collection-based values, tolerations, and normalization error scenarios (including expected failures).
* **Chores**
  * Added a JSON Schema used to exercise Helm values validation in tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->