### PR TITLE
🐛 Retry addon pre-delete hooks that terminally fail (e.g. eviction)

### DIFF
--- a/.github/workflows/go-presubmit.yml
+++ b/.github/workflows/go-presubmit.yml
@@ -11,6 +11,7 @@ env:
   # Common versions
   GO_VERSION: '1.25'
   GO_REQUIRED_MIN_VERSION: ''
+  KUBERNETES_VERSION: 'v1.35.0'
 
 jobs:
   verify:
@@ -105,10 +106,7 @@ jobs:
       - name: addon-examples-image # will build and tag the examples image
         run: imagebuilder --allow-pull -t quay.io/open-cluster-management/addon-examples:latest -t quay.io/ocm/addon-examples:latest -f ./build/Dockerfile.example .
       - name: setup kind
-        uses: engineerd/setup-kind@v0.6.2
-        with:
-          version: v0.31.0
-          name: cluster1
+        run: kind create cluster --name cluster1 --image kindest/node:${{ env.KUBERNETES_VERSION }} --wait 300s
       - name: Load image on the nodes of the cluster
         run: |
           kind load docker-image --name=cluster1 quay.io/open-cluster-management/addon-examples:latest
@@ -136,10 +134,7 @@ jobs:
       - name: addon-examples-image # will build and tag the examples image
         run: imagebuilder --allow-pull -t quay.io/open-cluster-management/addon-examples:latest -t quay.io/ocm/addon-examples:latest -f ./build/Dockerfile.example .
       - name: setup kind
-        uses: engineerd/setup-kind@v0.6.2
-        with:
-          version: v0.31.0
-          name: cluster1
+        run: kind create cluster --name cluster1 --image kindest/node:${{ env.KUBERNETES_VERSION }} --wait 300s
       - name: Load image on the nodes of the cluster
         run: |
           kind load docker-image --name=cluster1 quay.io/open-cluster-management/addon-examples:latest
@@ -167,10 +162,7 @@ jobs:
       - name: addon-examples-image # will build and tag the examples image
         run: imagebuilder --allow-pull -t quay.io/open-cluster-management/addon-examples:latest -t quay.io/ocm/addon-examples:latest -f ./build/Dockerfile.example .
       - name: setup kind
-        uses: engineerd/setup-kind@v0.6.2
-        with:
-          version: v0.31.0
-          name: cluster1
+        run: kind create cluster --name cluster1 --image kindest/node:${{ env.KUBERNETES_VERSION }} --wait 300s
       - name: Load image on the nodes of the cluster
         run: |
           kind load docker-image --name=cluster1 quay.io/open-cluster-management/addon-examples:latest
@@ -198,10 +190,7 @@ jobs:
       - name: addon-examples-image # will build and tag the examples image
         run: imagebuilder --allow-pull -t quay.io/open-cluster-management/addon-examples:latest -t quay.io/ocm/addon-examples:latest -f ./build/Dockerfile.example .
       - name: setup kind
-        uses: engineerd/setup-kind@v0.6.2
-        with:
-          version: v0.31.0
-          name: cluster1
+        run: kind create cluster --name cluster1 --image kindest/node:${{ env.KUBERNETES_VERSION }} --wait 300s
       - name: Load image on the nodes of the cluster
         run: |
           kind load docker-image --name=cluster1 quay.io/open-cluster-management/addon-examples:latest

--- a/pkg/addonmanager/controllers/agentdeploy/controller.go
+++ b/pkg/addonmanager/controllers/agentdeploy/controller.go
@@ -285,6 +285,7 @@ func (c *addonDeployController) sync(ctx context.Context, syncCtx factory.SyncCo
 				addonapiv1beta1.ManagedClusterAddOnManifestApplied,
 			),
 			applyWork:  c.applyWork,
+			deleteWork: c.workApplier.Delete,
 			agentAddon: agentAddon},
 		&hostedHookSyncer{
 			buildWorks: c.buildHookManifestWorkFunc(

--- a/pkg/addonmanager/controllers/agentdeploy/default_hook_sync.go
+++ b/pkg/addonmanager/controllers/agentdeploy/default_hook_sync.go
@@ -18,6 +18,7 @@ type defaultHookSyncer struct {
 	buildWorks buildDeployHookFunc
 	applyWork  func(ctx context.Context, appliedType string,
 		work *workapiv1.ManifestWork, addon *addonapiv1beta1.ManagedClusterAddOn) (*workapiv1.ManifestWork, error)
+	deleteWork func(ctx context.Context, workNamespace, workName string) error
 	agentAddon agent.AgentAddon
 }
 
@@ -61,6 +62,28 @@ func (s *defaultHookSyncer) sync(ctx context.Context,
 		})
 
 		addonRemoveFinalizer(addon, addonapiv1beta1.AddonPreDeleteHookFinalizer)
+		return addon, nil
+	}
+
+	// The hook has not completed. If the hook resource has reached a terminal
+	// failed state (e.g. the pod was evicted due to node pressure, its node
+	// became unreachable, or the job exhausted its backoffLimit), the work-agent
+	// will not recreate it on its own: the resource still exists with an
+	// unchanged spec, so a plain re-apply is a no-op. Delete the hook
+	// manifestWork so it is rebuilt and re-applied on a subsequent reconcile,
+	// which recreates a fresh hook pod/job. This retries indefinitely until the
+	// hook eventually succeeds, so the pre-delete hook finalizer is never left
+	// dangling because of a transient eviction.
+	if hookWorkIsFailed(hookWork) && hookWork.DeletionTimestamp.IsZero() {
+		if err = s.deleteWork(ctx, hookWork.Namespace, hookWork.Name); err != nil {
+			return addon, err
+		}
+		meta.SetStatusCondition(&addon.Status.Conditions, metav1.Condition{
+			Type:    addonapiv1beta1.ManagedClusterAddOnHookManifestCompleted,
+			Status:  metav1.ConditionFalse,
+			Reason:  "HookManifestFailedRetrying",
+			Message: fmt.Sprintf("hook manifestWork %v failed and is being recreated to retry.", hookWork.Name),
+		})
 		return addon, nil
 	}
 

--- a/pkg/addonmanager/controllers/agentdeploy/default_hook_sync_test.go
+++ b/pkg/addonmanager/controllers/agentdeploy/default_hook_sync_test.go
@@ -304,6 +304,115 @@ func TestDefaultHookReconcile(t *testing.T) {
 			},
 		},
 		{
+			name: "deploy hook manifest for a deleting addon with finalizer, failed, recreate to retry",
+			key:  "cluster1/test",
+			addon: []runtime.Object{
+				addontesting.SetAddonFinalizers(
+					addontesting.SetAddonDeletionTimestamp(
+						addontesting.NewAddonWithConditions("test", "cluster1", registrationAppliedCondition),
+						time.Now()),
+					addonapiv1beta1.AddonPreDeleteHookFinalizer),
+			},
+			cluster: []runtime.Object{addontesting.NewManagedCluster("cluster1")},
+			testaddon: &testAgent{name: "test", objects: []runtime.Object{
+				addontesting.NewUnstructured("v1", "ConfigMap", "default", "test"),
+				addontesting.NewHookJob("test", "default")}},
+			existingWork: []runtime.Object{
+				getDeployWork(),
+				func() *workapiv1.ManifestWork {
+					work := addontesting.NewManifestWork(
+						constants.PreDeleteHookWorkName("test"),
+						"cluster1",
+						addontesting.NewHookJob("test", "default"),
+					)
+					work.SetLabels(map[string]string{addonapiv1beta1.AddonLabelKey: "test"})
+					pTrue := true
+					work.SetOwnerReferences([]metav1.OwnerReference{
+						{
+							APIVersion:         "addon.open-cluster-management.io/v1beta1",
+							Kind:               "ManagedClusterAddOn",
+							Name:               "test",
+							UID:                "",
+							Controller:         &pTrue,
+							BlockOwnerDeletion: &pTrue,
+						},
+					})
+					work.Spec.ManifestConfigs = []workapiv1.ManifestConfigOption{
+						{
+							ResourceIdentifier: workapiv1.ResourceIdentifier{
+								Group:     "batch",
+								Resource:  "jobs",
+								Name:      "test",
+								Namespace: "default",
+							},
+							FeedbackRules: []workapiv1.FeedbackRule{
+								{
+									Type: workapiv1.WellKnownStatusType,
+								},
+							},
+						},
+					}
+					work.Status.Conditions = []metav1.Condition{
+						{
+							Type:   workapiv1.WorkApplied,
+							Status: metav1.ConditionTrue,
+						},
+						{
+							Type:   workapiv1.WorkAvailable,
+							Status: metav1.ConditionTrue,
+						},
+					}
+					work.Status.ResourceStatus = workapiv1.ManifestResourceStatus{
+						Manifests: []workapiv1.ManifestCondition{
+							{
+								ResourceMeta: workapiv1.ManifestResourceMeta{
+									Group:     "batch",
+									Version:   "v1",
+									Resource:  "jobs",
+									Name:      "test",
+									Namespace: "default",
+								},
+								StatusFeedbacks: workapiv1.StatusFeedbackResult{
+									Values: []workapiv1.FeedbackValue{
+										{
+											Name: "JobFailed",
+											Value: workapiv1.FieldValue{
+												Type:   workapiv1.String,
+												String: pointer.String("True"),
+											},
+										},
+									},
+								},
+							},
+						},
+					}
+					return work
+				}(),
+			},
+			validateWorkActions: func(t *testing.T, actions []clienttesting.Action) {
+				// the failed hook work is deleted so it will be recreated to retry.
+				addontesting.AssertActions(t, actions, "delete")
+				deleteAction := actions[0].(clienttesting.DeleteActionImpl)
+				if deleteAction.Namespace != "cluster1" || deleteAction.Name != constants.PreDeleteHookWorkName("test") {
+					t.Errorf("the deleted hookWork %v/%v is incorrect.", deleteAction.Namespace, deleteAction.Name)
+				}
+			},
+			validateAddonActions: func(t *testing.T, actions []clienttesting.Action) {
+				// Only a status patch is expected. The absence of an "update"
+				// action means the pre-delete hook finalizer is NOT removed, so
+				// deletion stays blocked until the hook succeeds.
+				addontesting.AssertActions(t, actions, "patch")
+				patch := actions[0].(clienttesting.PatchActionImpl).Patch
+				addOn := &addonapiv1beta1.ManagedClusterAddOn{}
+				if err := json.Unmarshal(patch, addOn); err != nil {
+					t.Fatal(err)
+				}
+				if !meta.IsStatusConditionFalse(addOn.Status.Conditions, addonapiv1beta1.ManagedClusterAddOnHookManifestCompleted) {
+					t.Errorf("HookManifestCompleted condition should be false while retrying.")
+				}
+			},
+		},
+		{
 			name: "deploy hook manifest for a deleting addon without finalizer, completed",
 			key:  "cluster1/test",
 			addon: []runtime.Object{

--- a/pkg/addonmanager/controllers/agentdeploy/hosted_hook_sync.go
+++ b/pkg/addonmanager/controllers/agentdeploy/hosted_hook_sync.go
@@ -112,14 +112,32 @@ func (s *hostedHookSyncer) sync(ctx context.Context,
 	}
 
 	// TODO: will surface more message here
-	if hookWorkIsCompleted(hookWork) {
+	switch {
+	case hookWorkIsCompleted(hookWork):
 		meta.SetStatusCondition(&addon.Status.Conditions, metav1.Condition{
 			Type:    addonapiv1beta1.ManagedClusterAddOnHookManifestCompleted,
 			Status:  metav1.ConditionTrue,
 			Reason:  "HookManifestIsCompleted",
 			Message: fmt.Sprintf("hook manifestWork %v is completed.", hookWork.Name),
 		})
-	} else {
+	case hookWorkIsFailed(hookWork) && hookWork.DeletionTimestamp.IsZero():
+		// The hook resource has reached a terminal failed state (e.g. the pod was
+		// evicted due to node pressure, its node became unreachable, or the job
+		// exhausted its backoffLimit). The work-agent will not recreate it on its
+		// own because the resource still exists with an unchanged spec. Delete the
+		// hook manifestWork so it is rebuilt and re-applied on a subsequent
+		// reconcile, recreating a fresh hook pod/job and retrying indefinitely
+		// until it succeeds.
+		if err = s.deleteWork(ctx, hookWork.Namespace, hookWork.Name); err != nil {
+			return addon, err
+		}
+		meta.SetStatusCondition(&addon.Status.Conditions, metav1.Condition{
+			Type:    addonapiv1beta1.ManagedClusterAddOnHookManifestCompleted,
+			Status:  metav1.ConditionFalse,
+			Reason:  "HookManifestFailedRetrying",
+			Message: fmt.Sprintf("hook manifestWork %v failed and is being recreated to retry.", hookWork.Name),
+		})
+	default:
 		meta.SetStatusCondition(&addon.Status.Conditions, metav1.Condition{
 			Type:    addonapiv1beta1.ManagedClusterAddOnHookManifestCompleted,
 			Status:  metav1.ConditionFalse,

--- a/pkg/addonmanager/controllers/agentdeploy/util_test.go
+++ b/pkg/addonmanager/controllers/agentdeploy/util_test.go
@@ -539,3 +539,226 @@ func TestMergeFeedbackRule(t *testing.T) {
 		})
 	}
 }
+
+func hookWorkWith(resource, feedbackName, feedbackValue string, available bool) *workapiv1.ManifestWork {
+	work := &workapiv1.ManifestWork{}
+	work.Spec.ManifestConfigs = []workapiv1.ManifestConfigOption{
+		{
+			ResourceIdentifier: workapiv1.ResourceIdentifier{
+				Resource:  resource,
+				Name:      "test",
+				Namespace: "default",
+			},
+		},
+	}
+	if available {
+		work.Status.Conditions = []metav1.Condition{
+			{Type: workapiv1.WorkAvailable, Status: metav1.ConditionTrue},
+		}
+	}
+	if feedbackName != "" {
+		v := feedbackValue
+		work.Status.ResourceStatus = workapiv1.ManifestResourceStatus{
+			Manifests: []workapiv1.ManifestCondition{
+				{
+					ResourceMeta: workapiv1.ManifestResourceMeta{
+						Resource:  resource,
+						Name:      "test",
+						Namespace: "default",
+					},
+					StatusFeedbacks: workapiv1.StatusFeedbackResult{
+						Values: []workapiv1.FeedbackValue{
+							{
+								Name: feedbackName,
+								Value: workapiv1.FieldValue{
+									Type:   workapiv1.String,
+									String: &v,
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+	}
+	return work
+}
+
+func TestHookWorkIsFailed(t *testing.T) {
+	cases := []struct {
+		name     string
+		work     *workapiv1.ManifestWork
+		expected bool
+	}{
+		{
+			name:     "nil work",
+			work:     nil,
+			expected: false,
+		},
+		{
+			name:     "work not available yet",
+			work:     hookWorkWith("pods", "PodPhase", "Failed", false),
+			expected: false,
+		},
+		{
+			name:     "evicted pod (phase Failed) is failed",
+			work:     hookWorkWith("pods", "PodPhase", "Failed", true),
+			expected: true,
+		},
+		{
+			name:     "pod with unknown phase is failed",
+			work:     hookWorkWith("pods", "PodPhase", "Unknown", true),
+			expected: true,
+		},
+		{
+			name:     "running pod is not failed",
+			work:     hookWorkWith("pods", "PodPhase", "Running", true),
+			expected: false,
+		},
+		{
+			name:     "succeeded pod is not failed",
+			work:     hookWorkWith("pods", "PodPhase", "Succeeded", true),
+			expected: false,
+		},
+		{
+			name:     "pod without reported phase is not failed",
+			work:     hookWorkWith("pods", "", "", true),
+			expected: false,
+		},
+		{
+			name:     "job with Failed condition true is failed",
+			work:     hookWorkWith("jobs", "JobFailed", "True", true),
+			expected: true,
+		},
+		{
+			name:     "job with Failed condition false is not failed",
+			work:     hookWorkWith("jobs", "JobFailed", "False", true),
+			expected: false,
+		},
+		{
+			name:     "job without failure feedback is not failed",
+			work:     hookWorkWith("jobs", "JobComplete", "True", true),
+			expected: false,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			assert.Equal(t, c.expected, hookWorkIsFailed(c.work))
+		})
+	}
+}
+
+func TestHookWorkIsCompleted(t *testing.T) {
+	cases := []struct {
+		name     string
+		work     *workapiv1.ManifestWork
+		expected bool
+	}{
+		{
+			name:     "nil work",
+			work:     nil,
+			expected: false,
+		},
+		{
+			name:     "succeeded pod is completed",
+			work:     hookWorkWith("pods", "PodPhase", "Succeeded", true),
+			expected: true,
+		},
+		{
+			name:     "failed pod is not completed",
+			work:     hookWorkWith("pods", "PodPhase", "Failed", true),
+			expected: false,
+		},
+		{
+			name:     "unknown pod is not completed",
+			work:     hookWorkWith("pods", "PodPhase", "Unknown", true),
+			expected: false,
+		},
+		{
+			name:     "complete job is completed",
+			work:     hookWorkWith("jobs", "JobComplete", "True", true),
+			expected: true,
+		},
+		{
+			name:     "failed job is not completed",
+			work:     hookWorkWith("jobs", "JobFailed", "True", true),
+			expected: false,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			assert.Equal(t, c.expected, hookWorkIsCompleted(c.work))
+		})
+	}
+}
+
+// TestHookWorkIsFailedWithUnreportedFirstManifest is a regression test for a
+// hook work whose first manifest has no feedback values reported yet (e.g. the
+// work-agent has not observed it) followed by a second hook resource that has
+// terminally failed. The failure of the later resource must still be detected.
+func TestHookWorkIsFailedWithUnreportedFirstManifest(t *testing.T) {
+	failedValue := "Failed"
+	work := &workapiv1.ManifestWork{}
+	work.Spec.ManifestConfigs = []workapiv1.ManifestConfigOption{
+		{
+			ResourceIdentifier: workapiv1.ResourceIdentifier{
+				Resource:  "pods",
+				Name:      "hook-1",
+				Namespace: "default",
+			},
+		},
+		{
+			ResourceIdentifier: workapiv1.ResourceIdentifier{
+				Resource:  "pods",
+				Name:      "hook-2",
+				Namespace: "default",
+			},
+		},
+	}
+	work.Status.Conditions = []metav1.Condition{
+		{Type: workapiv1.WorkAvailable, Status: metav1.ConditionTrue},
+	}
+	work.Status.ResourceStatus = workapiv1.ManifestResourceStatus{
+		Manifests: []workapiv1.ManifestCondition{
+			{
+				// First manifest has no feedback values reported yet.
+				ResourceMeta: workapiv1.ManifestResourceMeta{
+					Resource:  "pods",
+					Name:      "hook-1",
+					Namespace: "default",
+				},
+				StatusFeedbacks: workapiv1.StatusFeedbackResult{},
+			},
+			{
+				// Second manifest has terminally failed (evicted).
+				ResourceMeta: workapiv1.ManifestResourceMeta{
+					Resource:  "pods",
+					Name:      "hook-2",
+					Namespace: "default",
+				},
+				StatusFeedbacks: workapiv1.StatusFeedbackResult{
+					Values: []workapiv1.FeedbackValue{
+						{
+							Name: "PodPhase",
+							Value: workapiv1.FieldValue{
+								Type:   workapiv1.String,
+								String: &failedValue,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	if !hookWorkIsFailed(work) {
+		t.Errorf("expected the failed second hook resource to be detected even though the first manifest has no feedback reported")
+	}
+	// FindManifestValue must locate the failed pod's phase directly.
+	v := FindManifestValue(work.Status.ResourceStatus, work.Spec.ManifestConfigs[1].ResourceIdentifier, "PodPhase")
+	if v.String == nil || *v.String != "Failed" {
+		t.Errorf("expected FindManifestValue to return PodPhase=Failed for the second manifest, got %+v", v)
+	}
+}

--- a/pkg/addonmanager/controllers/agentdeploy/utils.go
+++ b/pkg/addonmanager/controllers/agentdeploy/utils.go
@@ -11,6 +11,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/klog/v2"
+
+	corev1 "k8s.io/api/core/v1"
 	addonapiv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
 	addonapiv1beta1 "open-cluster-management.io/api/addon/v1beta1"
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
@@ -20,6 +22,12 @@ import (
 	"open-cluster-management.io/addon-framework/pkg/addonmanager/constants"
 	"open-cluster-management.io/addon-framework/pkg/agent"
 	"open-cluster-management.io/addon-framework/pkg/utils"
+)
+
+// Work API resource names for the pre-delete hook resource kinds we support.
+const (
+	hookResourceJobs = "jobs"
+	hookResourcePods = "pods"
 )
 
 func addonHasFinalizer(addon *addonapiv1beta1.ManagedClusterAddOn, finalizer string) bool {
@@ -116,9 +124,9 @@ func (b *addonWorksBuilder) isPreDeleteHookObject(obj runtime.Object) (bool, *wo
 	gvk := obj.GetObjectKind().GroupVersionKind()
 	switch gvk.Kind {
 	case "Job":
-		resource = "jobs"
+		resource = hookResourceJobs
 	case "Pod":
-		resource = "pods"
+		resource = hookResourcePods
 	default:
 		return false, nil
 	}
@@ -387,19 +395,20 @@ func FindManifestValue(
 	identifier workapiv1.ResourceIdentifier,
 	valueName string) workapiv1.FieldValue {
 	for _, manifest := range resourceStatus.Manifests {
-		values := manifest.StatusFeedbacks.Values
-		if len(values) == 0 {
-			return workapiv1.FieldValue{}
-		}
+		// Match the resource first. A manifest that does not match the requested
+		// identifier - including one that has no feedback values reported yet -
+		// must not short-circuit the search, otherwise a later matching resource
+		// (e.g. a pod that reports PodPhase=Failed) would be missed.
 		resourceMeta := manifest.ResourceMeta
-		if identifier.Group == resourceMeta.Group &&
-			identifier.Resource == resourceMeta.Resource &&
-			identifier.Name == resourceMeta.Name &&
-			identifier.Namespace == resourceMeta.Namespace {
-			for _, v := range values {
-				if v.Name == valueName {
-					return v.Value
-				}
+		if identifier.Group != resourceMeta.Group ||
+			identifier.Resource != resourceMeta.Resource ||
+			identifier.Name != resourceMeta.Name ||
+			identifier.Namespace != resourceMeta.Namespace {
+			continue
+		}
+		for _, v := range manifest.StatusFeedbacks.Values {
+			if v.Name == valueName {
+				return v.Value
 			}
 		}
 	}
@@ -425,7 +434,7 @@ func hookWorkIsCompleted(hookWork *workapiv1.ManifestWork) bool {
 	}
 	for _, manifestConfig := range hookWork.Spec.ManifestConfigs {
 		switch manifestConfig.ResourceIdentifier.Resource {
-		case "jobs":
+		case hookResourceJobs:
 			value := FindManifestValue(hookWork.Status.ResourceStatus, manifestConfig.ResourceIdentifier, "JobComplete")
 			if value.Type == "" {
 				return false
@@ -433,11 +442,11 @@ func hookWorkIsCompleted(hookWork *workapiv1.ManifestWork) bool {
 			if value.String == nil {
 				return false
 			}
-			if *value.String != "True" {
+			if *value.String != string(metav1.ConditionTrue) {
 				return false
 			}
 
-		case "pods":
+		case hookResourcePods:
 			value := FindManifestValue(hookWork.Status.ResourceStatus, manifestConfig.ResourceIdentifier, "PodPhase")
 			if value.Type == "" {
 				return false
@@ -445,7 +454,7 @@ func hookWorkIsCompleted(hookWork *workapiv1.ManifestWork) bool {
 			if value.String == nil {
 				return false
 			}
-			if *value.String != "Succeeded" {
+			if *value.String != string(corev1.PodSucceeded) {
 				return false
 			}
 		default:
@@ -454,6 +463,63 @@ func hookWorkIsCompleted(hookWork *workapiv1.ManifestWork) bool {
 	}
 
 	return true
+}
+
+// hookWorkIsFailed checks whether any hook resource has reached a terminal
+// failed state and therefore should be recreated/retried.
+//
+// We deliberately treat *any* terminal, non-succeeded state as a failure that
+// warrants a retry, because a hook that never runs to completion will otherwise
+// block removal of the pre-delete hook finalizer forever (and, in turn, block
+// deletion of the ManagedClusterAddOn and its owning ManagedCluster). This
+// covers, among others:
+//   - pods evicted due to node pressure (MemoryPressure/DiskPressure), which end
+//     up in phase "Failed" with reason "Evicted";
+//   - pods whose status can no longer be determined, phase "Unknown" (e.g. the
+//     node hosting the pod became unreachable);
+//   - jobs that have exhausted their backoffLimit and report a "Failed"
+//     condition.
+//
+// A hook is only considered failed once the work-agent has reported a definitive
+// terminal state; in-progress states (Pending/Running, or no status reported
+// yet) are not treated as failures.
+func hookWorkIsFailed(hookWork *workapiv1.ManifestWork) bool {
+	if hookWork == nil {
+		return false
+	}
+	if !meta.IsStatusConditionTrue(hookWork.Status.Conditions, workapiv1.WorkAvailable) {
+		return false
+	}
+	if len(hookWork.Spec.ManifestConfigs) == 0 {
+		return false
+	}
+
+	for _, manifestConfig := range hookWork.Spec.ManifestConfigs {
+		switch manifestConfig.ResourceIdentifier.Resource {
+		case hookResourceJobs:
+			// A job reports a "Failed" condition once it has exhausted its
+			// backoffLimit (or hit an activeDeadlineSeconds/podFailurePolicy).
+			value := FindManifestValue(hookWork.Status.ResourceStatus, manifestConfig.ResourceIdentifier, "JobFailed")
+			if value.Type == workapiv1.String && value.String != nil && *value.String == string(metav1.ConditionTrue) {
+				return true
+			}
+		case hookResourcePods:
+			// A pod is terminally failed when its phase is "Failed" (this
+			// includes evicted pods) or "Unknown" (the pod's status can no
+			// longer be determined, e.g. its node is unreachable).
+			value := FindManifestValue(hookWork.Status.ResourceStatus, manifestConfig.ResourceIdentifier, "PodPhase")
+			if value.Type == workapiv1.String && value.String != nil &&
+				(*value.String == string(corev1.PodFailed) || *value.String == string(corev1.PodUnknown)) {
+				return true
+			}
+		default:
+			// Unsupported hook resource kinds cannot be evaluated for failure;
+			// leave them to hookWorkIsCompleted's handling.
+			continue
+		}
+	}
+
+	return false
 }
 
 func newAddonWorkObjectMeta(namePrefix, addonName, addonNamespace, workNamespace string,


### PR DESCRIPTION
When an addon pre-delete hook Pod/Job is evicted (MemoryPressure, DiskPressure), loses its node (phase Unknown), or a hook Job exhausts its backoffLimit, the resource lands in a terminal non-succeeded state. The work-agent does not recreate it (the resource still exists with an unchanged spec, so a re-apply is a no-op), and hookWorkIsCompleted only recognizes success. As a result the pre-delete hook finalizer is never removed and the ManagedClusterAddOn (and its owning ManagedCluster) hang on deletion forever.

Detect any terminal failure of a hook resource (pod phase Failed or Unknown, or job Failed condition) and delete the hook manifestWork so it is rebuilt and re-applied, recreating a fresh hook pod/job. This retries indefinitely until the hook succeeds, so a transient eviction no longer blocks deletion.

The job Failed detection relies on a new JobFailed WellKnownStatus feedback value surfaced by the work-agent.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Failed addon deployment hooks are now detected more accurately for Jobs and Pods.
  * Failed hooks are automatically deleted and retried during the next reconciliation.
  * Addon status now clearly indicates when hook processing is retrying.
  * Deletion errors are surfaced immediately, while completion remains pending until successful retry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->