### PR TITLE
:bug: fix: retry addon pre-delete hooks that terminally fail (cherry-picked from #390)

### DIFF
--- a/pkg/addonmanager/controllers/agentdeploy/controller.go
+++ b/pkg/addonmanager/controllers/agentdeploy/controller.go
@@ -347,6 +347,7 @@ func (c *addonDeployController) sync(ctx context.Context, syncCtx factory.SyncCo
 				addonapiv1beta1.ManagedClusterAddOnManifestApplied,
 			),
 			applyWork:  c.applyWork,
+			deleteWork: c.workApplier.Delete,
 			agentAddon: agentAddon,
 		})
 	}

--- a/pkg/addonmanager/controllers/agentdeploy/default_hook_sync.go
+++ b/pkg/addonmanager/controllers/agentdeploy/default_hook_sync.go
@@ -19,6 +19,7 @@ type defaultHookSyncer struct {
 	buildWorks buildDeployHookFunc
 	applyWork  func(ctx context.Context, appliedType string,
 		work *workapiv1.ManifestWork, addon *addonapiv1beta1.ManagedClusterAddOn) (*workapiv1.ManifestWork, error)
+	deleteWork func(ctx context.Context, workNamespace, workName string) error
 	agentAddon agent.AgentAddon
 }
 
@@ -62,6 +63,28 @@ func (s *defaultHookSyncer) sync(ctx context.Context,
 		})
 
 		addonRemoveFinalizer(addon, addonapiv1beta1.AddonPreDeleteHookFinalizer)
+		return addon, nil
+	}
+
+	// The hook has not completed. If the hook resource has reached a terminal
+	// failed state (e.g. the pod was evicted due to node pressure, its node
+	// became unreachable, or the job exhausted its backoffLimit), the work-agent
+	// will not recreate it on its own: the resource still exists with an
+	// unchanged spec, so a plain re-apply is a no-op. Delete the hook
+	// manifestWork so it is rebuilt and re-applied on a subsequent reconcile,
+	// which recreates a fresh hook pod/job. This retries indefinitely until the
+	// hook eventually succeeds, so the pre-delete hook finalizer is never left
+	// dangling because of a transient eviction.
+	if hookWorkIsFailed(hookWork) && hookWork.DeletionTimestamp.IsZero() {
+		if err = s.deleteWork(ctx, hookWork.Namespace, hookWork.Name); err != nil {
+			return addon, err
+		}
+		meta.SetStatusCondition(&addon.Status.Conditions, metav1.Condition{
+			Type:    addonapiv1beta1.ManagedClusterAddOnHookManifestCompleted,
+			Status:  metav1.ConditionFalse,
+			Reason:  "HookManifestFailedRetrying",
+			Message: fmt.Sprintf("hook manifestWork %v failed and is being recreated to retry.", hookWork.Name),
+		})
 		return addon, nil
 	}
 

--- a/pkg/addonmanager/controllers/agentdeploy/default_hook_sync_test.go
+++ b/pkg/addonmanager/controllers/agentdeploy/default_hook_sync_test.go
@@ -304,6 +304,115 @@ func TestDefaultHookReconcile(t *testing.T) {
 			},
 		},
 		{
+			name: "deploy hook manifest for a deleting addon with finalizer, failed, recreate to retry",
+			key:  "cluster1/test",
+			addon: []runtime.Object{
+				addontesting.SetAddonFinalizers(
+					addontesting.SetAddonDeletionTimestamp(
+						addontesting.NewAddonWithConditions("test", "cluster1", registrationAppliedCondition),
+						time.Now()),
+					addonapiv1beta1.AddonPreDeleteHookFinalizer),
+			},
+			cluster: []runtime.Object{addontesting.NewManagedCluster("cluster1")},
+			testaddon: &testAgent{name: "test", objects: []runtime.Object{
+				addontesting.NewUnstructured("v1", "ConfigMap", "default", "test"),
+				addontesting.NewHookJob("test", "default")}},
+			existingWork: []runtime.Object{
+				getDeployWork(),
+				func() *workapiv1.ManifestWork {
+					work := addontesting.NewManifestWork(
+						constants.PreDeleteHookWorkName("test"),
+						"cluster1",
+						addontesting.NewHookJob("test", "default"),
+					)
+					work.SetLabels(map[string]string{addonapiv1beta1.AddonLabelKey: "test"})
+					pTrue := true
+					work.SetOwnerReferences([]metav1.OwnerReference{
+						{
+							APIVersion:         "addon.open-cluster-management.io/v1beta1",
+							Kind:               "ManagedClusterAddOn",
+							Name:               "test",
+							UID:                "",
+							Controller:         &pTrue,
+							BlockOwnerDeletion: &pTrue,
+						},
+					})
+					work.Spec.ManifestConfigs = []workapiv1.ManifestConfigOption{
+						{
+							ResourceIdentifier: workapiv1.ResourceIdentifier{
+								Group:     "batch",
+								Resource:  "jobs",
+								Name:      "test",
+								Namespace: "default",
+							},
+							FeedbackRules: []workapiv1.FeedbackRule{
+								{
+									Type: workapiv1.WellKnownStatusType,
+								},
+							},
+						},
+					}
+					work.Status.Conditions = []metav1.Condition{
+						{
+							Type:   workapiv1.WorkApplied,
+							Status: metav1.ConditionTrue,
+						},
+						{
+							Type:   workapiv1.WorkAvailable,
+							Status: metav1.ConditionTrue,
+						},
+					}
+					work.Status.ResourceStatus = workapiv1.ManifestResourceStatus{
+						Manifests: []workapiv1.ManifestCondition{
+							{
+								ResourceMeta: workapiv1.ManifestResourceMeta{
+									Group:     "batch",
+									Version:   "v1",
+									Resource:  "jobs",
+									Name:      "test",
+									Namespace: "default",
+								},
+								StatusFeedbacks: workapiv1.StatusFeedbackResult{
+									Values: []workapiv1.FeedbackValue{
+										{
+											Name: "JobFailed",
+											Value: workapiv1.FieldValue{
+												Type:   workapiv1.String,
+												String: pointer.String("True"),
+											},
+										},
+									},
+								},
+							},
+						},
+					}
+					return work
+				}(),
+			},
+			validateWorkActions: func(t *testing.T, actions []clienttesting.Action) {
+				// the failed hook work is deleted so it will be recreated to retry.
+				addontesting.AssertActions(t, actions, "delete")
+				deleteAction := actions[0].(clienttesting.DeleteActionImpl)
+				if deleteAction.Namespace != "cluster1" || deleteAction.Name != constants.PreDeleteHookWorkName("test") {
+					t.Errorf("the deleted hookWork %v/%v is incorrect.", deleteAction.Namespace, deleteAction.Name)
+				}
+			},
+			validateAddonActions: func(t *testing.T, actions []clienttesting.Action) {
+				// Only a status patch is expected. The absence of an "update"
+				// action means the pre-delete hook finalizer is NOT removed, so
+				// deletion stays blocked until the hook succeeds.
+				addontesting.AssertActions(t, actions, "patch")
+				patch := actions[0].(clienttesting.PatchActionImpl).Patch
+				addOn := &addonapiv1beta1.ManagedClusterAddOn{}
+				if err := json.Unmarshal(patch, addOn); err != nil {
+					t.Fatal(err)
+				}
+				if !meta.IsStatusConditionFalse(addOn.Status.Conditions, addonapiv1beta1.ManagedClusterAddOnHookManifestCompleted) {
+					t.Errorf("HookManifestCompleted condition should be false while retrying.")
+				}
+			},
+		},
+		{
 			name: "deploy hook manifest for a deleting addon without finalizer, completed",
 			key:  "cluster1/test",
 			addon: []runtime.Object{

--- a/pkg/addonmanager/controllers/agentdeploy/hosted_hook_sync.go
+++ b/pkg/addonmanager/controllers/agentdeploy/hosted_hook_sync.go
@@ -136,14 +136,32 @@ func (s *hostedHookSyncer) sync(ctx context.Context,
 	}
 
 	// TODO: will surface more message here
-	if hookWorkIsCompleted(hookWork) {
+	switch {
+	case hookWorkIsCompleted(hookWork):
 		meta.SetStatusCondition(&addon.Status.Conditions, metav1.Condition{
 			Type:    addonapiv1beta1.ManagedClusterAddOnHookManifestCompleted,
 			Status:  metav1.ConditionTrue,
 			Reason:  "HookManifestIsCompleted",
 			Message: fmt.Sprintf("hook manifestWork %v is completed.", hookWork.Name),
 		})
-	} else {
+	case hookWorkIsFailed(hookWork) && hookWork.DeletionTimestamp.IsZero():
+		// The hook resource has reached a terminal failed state (e.g. the pod was
+		// evicted due to node pressure, its node became unreachable, or the job
+		// exhausted its backoffLimit). The work-agent will not recreate it on its
+		// own because the resource still exists with an unchanged spec. Delete the
+		// hook manifestWork so it is rebuilt and re-applied on a subsequent
+		// reconcile, recreating a fresh hook pod/job and retrying indefinitely
+		// until it succeeds.
+		if err = s.deleteWork(ctx, hookWork.Namespace, hookWork.Name); err != nil {
+			return addon, err
+		}
+		meta.SetStatusCondition(&addon.Status.Conditions, metav1.Condition{
+			Type:    addonapiv1beta1.ManagedClusterAddOnHookManifestCompleted,
+			Status:  metav1.ConditionFalse,
+			Reason:  "HookManifestFailedRetrying",
+			Message: fmt.Sprintf("hook manifestWork %v failed and is being recreated to retry.", hookWork.Name),
+		})
+	default:
 		meta.SetStatusCondition(&addon.Status.Conditions, metav1.Condition{
 			Type:    addonapiv1beta1.ManagedClusterAddOnHookManifestCompleted,
 			Status:  metav1.ConditionFalse,

--- a/pkg/addonmanager/controllers/agentdeploy/util_test.go
+++ b/pkg/addonmanager/controllers/agentdeploy/util_test.go
@@ -539,3 +539,226 @@ func TestMergeFeedbackRule(t *testing.T) {
 		})
 	}
 }
+
+func hookWorkWith(resource, feedbackName, feedbackValue string, available bool) *workapiv1.ManifestWork {
+	work := &workapiv1.ManifestWork{}
+	work.Spec.ManifestConfigs = []workapiv1.ManifestConfigOption{
+		{
+			ResourceIdentifier: workapiv1.ResourceIdentifier{
+				Resource:  resource,
+				Name:      "test",
+				Namespace: "default",
+			},
+		},
+	}
+	if available {
+		work.Status.Conditions = []metav1.Condition{
+			{Type: workapiv1.WorkAvailable, Status: metav1.ConditionTrue},
+		}
+	}
+	if feedbackName != "" {
+		v := feedbackValue
+		work.Status.ResourceStatus = workapiv1.ManifestResourceStatus{
+			Manifests: []workapiv1.ManifestCondition{
+				{
+					ResourceMeta: workapiv1.ManifestResourceMeta{
+						Resource:  resource,
+						Name:      "test",
+						Namespace: "default",
+					},
+					StatusFeedbacks: workapiv1.StatusFeedbackResult{
+						Values: []workapiv1.FeedbackValue{
+							{
+								Name: feedbackName,
+								Value: workapiv1.FieldValue{
+									Type:   workapiv1.String,
+									String: &v,
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+	}
+	return work
+}
+
+func TestHookWorkIsFailed(t *testing.T) {
+	cases := []struct {
+		name     string
+		work     *workapiv1.ManifestWork
+		expected bool
+	}{
+		{
+			name:     "nil work",
+			work:     nil,
+			expected: false,
+		},
+		{
+			name:     "work not available yet",
+			work:     hookWorkWith("pods", "PodPhase", "Failed", false),
+			expected: false,
+		},
+		{
+			name:     "evicted pod (phase Failed) is failed",
+			work:     hookWorkWith("pods", "PodPhase", "Failed", true),
+			expected: true,
+		},
+		{
+			name:     "pod with unknown phase is failed",
+			work:     hookWorkWith("pods", "PodPhase", "Unknown", true),
+			expected: true,
+		},
+		{
+			name:     "running pod is not failed",
+			work:     hookWorkWith("pods", "PodPhase", "Running", true),
+			expected: false,
+		},
+		{
+			name:     "succeeded pod is not failed",
+			work:     hookWorkWith("pods", "PodPhase", "Succeeded", true),
+			expected: false,
+		},
+		{
+			name:     "pod without reported phase is not failed",
+			work:     hookWorkWith("pods", "", "", true),
+			expected: false,
+		},
+		{
+			name:     "job with Failed condition true is failed",
+			work:     hookWorkWith("jobs", "JobFailed", "True", true),
+			expected: true,
+		},
+		{
+			name:     "job with Failed condition false is not failed",
+			work:     hookWorkWith("jobs", "JobFailed", "False", true),
+			expected: false,
+		},
+		{
+			name:     "job without failure feedback is not failed",
+			work:     hookWorkWith("jobs", "JobComplete", "True", true),
+			expected: false,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			assert.Equal(t, c.expected, hookWorkIsFailed(c.work))
+		})
+	}
+}
+
+func TestHookWorkIsCompleted(t *testing.T) {
+	cases := []struct {
+		name     string
+		work     *workapiv1.ManifestWork
+		expected bool
+	}{
+		{
+			name:     "nil work",
+			work:     nil,
+			expected: false,
+		},
+		{
+			name:     "succeeded pod is completed",
+			work:     hookWorkWith("pods", "PodPhase", "Succeeded", true),
+			expected: true,
+		},
+		{
+			name:     "failed pod is not completed",
+			work:     hookWorkWith("pods", "PodPhase", "Failed", true),
+			expected: false,
+		},
+		{
+			name:     "unknown pod is not completed",
+			work:     hookWorkWith("pods", "PodPhase", "Unknown", true),
+			expected: false,
+		},
+		{
+			name:     "complete job is completed",
+			work:     hookWorkWith("jobs", "JobComplete", "True", true),
+			expected: true,
+		},
+		{
+			name:     "failed job is not completed",
+			work:     hookWorkWith("jobs", "JobFailed", "True", true),
+			expected: false,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			assert.Equal(t, c.expected, hookWorkIsCompleted(c.work))
+		})
+	}
+}
+
+// TestHookWorkIsFailedWithUnreportedFirstManifest is a regression test for a
+// hook work whose first manifest has no feedback values reported yet (e.g. the
+// work-agent has not observed it) followed by a second hook resource that has
+// terminally failed. The failure of the later resource must still be detected.
+func TestHookWorkIsFailedWithUnreportedFirstManifest(t *testing.T) {
+	failedValue := "Failed"
+	work := &workapiv1.ManifestWork{}
+	work.Spec.ManifestConfigs = []workapiv1.ManifestConfigOption{
+		{
+			ResourceIdentifier: workapiv1.ResourceIdentifier{
+				Resource:  "pods",
+				Name:      "hook-1",
+				Namespace: "default",
+			},
+		},
+		{
+			ResourceIdentifier: workapiv1.ResourceIdentifier{
+				Resource:  "pods",
+				Name:      "hook-2",
+				Namespace: "default",
+			},
+		},
+	}
+	work.Status.Conditions = []metav1.Condition{
+		{Type: workapiv1.WorkAvailable, Status: metav1.ConditionTrue},
+	}
+	work.Status.ResourceStatus = workapiv1.ManifestResourceStatus{
+		Manifests: []workapiv1.ManifestCondition{
+			{
+				// First manifest has no feedback values reported yet.
+				ResourceMeta: workapiv1.ManifestResourceMeta{
+					Resource:  "pods",
+					Name:      "hook-1",
+					Namespace: "default",
+				},
+				StatusFeedbacks: workapiv1.StatusFeedbackResult{},
+			},
+			{
+				// Second manifest has terminally failed (evicted).
+				ResourceMeta: workapiv1.ManifestResourceMeta{
+					Resource:  "pods",
+					Name:      "hook-2",
+					Namespace: "default",
+				},
+				StatusFeedbacks: workapiv1.StatusFeedbackResult{
+					Values: []workapiv1.FeedbackValue{
+						{
+							Name: "PodPhase",
+							Value: workapiv1.FieldValue{
+								Type:   workapiv1.String,
+								String: &failedValue,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	if !hookWorkIsFailed(work) {
+		t.Errorf("expected the failed second hook resource to be detected even though the first manifest has no feedback reported")
+	}
+	// FindManifestValue must locate the failed pod's phase directly.
+	v := FindManifestValue(work.Status.ResourceStatus, work.Spec.ManifestConfigs[1].ResourceIdentifier, "PodPhase")
+	if v.String == nil || *v.String != "Failed" {
+		t.Errorf("expected FindManifestValue to return PodPhase=Failed for the second manifest, got %+v", v)
+	}
+}

--- a/pkg/addonmanager/controllers/agentdeploy/utils.go
+++ b/pkg/addonmanager/controllers/agentdeploy/utils.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -21,6 +22,12 @@ import (
 	"open-cluster-management.io/addon-framework/pkg/addonmanager/constants"
 	"open-cluster-management.io/addon-framework/pkg/agent"
 	"open-cluster-management.io/addon-framework/pkg/utils"
+)
+
+// Work API resource names for the pre-delete hook resource kinds we support.
+const (
+	hookResourceJobs = "jobs"
+	hookResourcePods = "pods"
 )
 
 func addonHasFinalizer(addon *addonapiv1beta1.ManagedClusterAddOn, finalizer string) bool {
@@ -117,9 +124,9 @@ func (b *addonWorksBuilder) isPreDeleteHookObject(obj runtime.Object) (bool, *wo
 	gvk := obj.GetObjectKind().GroupVersionKind()
 	switch gvk.Kind {
 	case "Job":
-		resource = "jobs"
+		resource = hookResourceJobs
 	case "Pod":
-		resource = "pods"
+		resource = hookResourcePods
 	default:
 		return false, nil
 	}
@@ -388,19 +395,20 @@ func FindManifestValue(
 	identifier workapiv1.ResourceIdentifier,
 	valueName string) workapiv1.FieldValue {
 	for _, manifest := range resourceStatus.Manifests {
-		values := manifest.StatusFeedbacks.Values
-		if len(values) == 0 {
-			return workapiv1.FieldValue{}
-		}
+		// Match the resource first. A manifest that does not match the requested
+		// identifier - including one that has no feedback values reported yet -
+		// must not short-circuit the search, otherwise a later matching resource
+		// (e.g. a pod that reports PodPhase=Failed) would be missed.
 		resourceMeta := manifest.ResourceMeta
-		if identifier.Group == resourceMeta.Group &&
-			identifier.Resource == resourceMeta.Resource &&
-			identifier.Name == resourceMeta.Name &&
-			identifier.Namespace == resourceMeta.Namespace {
-			for _, v := range values {
-				if v.Name == valueName {
-					return v.Value
-				}
+		if identifier.Group != resourceMeta.Group ||
+			identifier.Resource != resourceMeta.Resource ||
+			identifier.Name != resourceMeta.Name ||
+			identifier.Namespace != resourceMeta.Namespace {
+			continue
+		}
+		for _, v := range manifest.StatusFeedbacks.Values {
+			if v.Name == valueName {
+				return v.Value
 			}
 		}
 	}
@@ -426,7 +434,7 @@ func hookWorkIsCompleted(hookWork *workapiv1.ManifestWork) bool {
 	}
 	for _, manifestConfig := range hookWork.Spec.ManifestConfigs {
 		switch manifestConfig.ResourceIdentifier.Resource {
-		case "jobs":
+		case hookResourceJobs:
 			value := FindManifestValue(hookWork.Status.ResourceStatus, manifestConfig.ResourceIdentifier, "JobComplete")
 			if value.Type == "" {
 				return false
@@ -434,11 +442,11 @@ func hookWorkIsCompleted(hookWork *workapiv1.ManifestWork) bool {
 			if value.String == nil {
 				return false
 			}
-			if *value.String != "True" {
+			if *value.String != string(metav1.ConditionTrue) {
 				return false
 			}
 
-		case "pods":
+		case hookResourcePods:
 			value := FindManifestValue(hookWork.Status.ResourceStatus, manifestConfig.ResourceIdentifier, "PodPhase")
 			if value.Type == "" {
 				return false
@@ -446,7 +454,7 @@ func hookWorkIsCompleted(hookWork *workapiv1.ManifestWork) bool {
 			if value.String == nil {
 				return false
 			}
-			if *value.String != "Succeeded" {
+			if *value.String != string(corev1.PodSucceeded) {
 				return false
 			}
 		default:
@@ -455,6 +463,63 @@ func hookWorkIsCompleted(hookWork *workapiv1.ManifestWork) bool {
 	}
 
 	return true
+}
+
+// hookWorkIsFailed checks whether any hook resource has reached a terminal
+// failed state and therefore should be recreated/retried.
+//
+// We deliberately treat *any* terminal, non-succeeded state as a failure that
+// warrants a retry, because a hook that never runs to completion will otherwise
+// block removal of the pre-delete hook finalizer forever (and, in turn, block
+// deletion of the ManagedClusterAddOn and its owning ManagedCluster). This
+// covers, among others:
+//   - pods evicted due to node pressure (MemoryPressure/DiskPressure), which end
+//     up in phase "Failed" with reason "Evicted";
+//   - pods whose status can no longer be determined, phase "Unknown" (e.g. the
+//     node hosting the pod became unreachable);
+//   - jobs that have exhausted their backoffLimit and report a "Failed"
+//     condition.
+//
+// A hook is only considered failed once the work-agent has reported a definitive
+// terminal state; in-progress states (Pending/Running, or no status reported
+// yet) are not treated as failures.
+func hookWorkIsFailed(hookWork *workapiv1.ManifestWork) bool {
+	if hookWork == nil {
+		return false
+	}
+	if !meta.IsStatusConditionTrue(hookWork.Status.Conditions, workapiv1.WorkAvailable) {
+		return false
+	}
+	if len(hookWork.Spec.ManifestConfigs) == 0 {
+		return false
+	}
+
+	for _, manifestConfig := range hookWork.Spec.ManifestConfigs {
+		switch manifestConfig.ResourceIdentifier.Resource {
+		case hookResourceJobs:
+			// A job reports a "Failed" condition once it has exhausted its
+			// backoffLimit (or hit an activeDeadlineSeconds/podFailurePolicy).
+			value := FindManifestValue(hookWork.Status.ResourceStatus, manifestConfig.ResourceIdentifier, "JobFailed")
+			if value.Type == workapiv1.String && value.String != nil && *value.String == string(metav1.ConditionTrue) {
+				return true
+			}
+		case hookResourcePods:
+			// A pod is terminally failed when its phase is "Failed" (this
+			// includes evicted pods) or "Unknown" (the pod's status can no
+			// longer be determined, e.g. its node is unreachable).
+			value := FindManifestValue(hookWork.Status.ResourceStatus, manifestConfig.ResourceIdentifier, "PodPhase")
+			if value.Type == workapiv1.String && value.String != nil &&
+				(*value.String == string(corev1.PodFailed) || *value.String == string(corev1.PodUnknown)) {
+				return true
+			}
+		default:
+			// Unsupported hook resource kinds cannot be evaluated for failure;
+			// leave them to hookWorkIsCompleted's handling.
+			continue
+		}
+	}
+
+	return false
 }
 
 func newAddonWorkObjectMeta(namePrefix, addonName, addonNamespace, workNamespace string,


### PR DESCRIPTION

<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:rocket: 🚀 release
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
fix: retry addon pre-delete hooks that terminally fail (cherry-picked from #390)

## Related issue(s)

#390 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Failed pre-delete hooks now automatically retry when their workload reaches a terminal failure state.
  * Obsolete hook resources are cleaned up and recreated during a later reconciliation.
  * Add-on deletion remains safely blocked until the pre-delete hook completes successfully.
  * Improved detection of failed hook workloads, including jobs and pods, even when earlier resources lack status feedback.
* **Tests**
  * Added coverage for failed, completed, unavailable, and retryable hook scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->